### PR TITLE
perf: consolidate per-slot state into one AtomicUsize

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,12 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     needs: check
-    
+
     steps:
       - uses: actions/checkout@master
       - uses: actions-rs/cargo@v1
         with:
           command: test
           args: --all-features
+        env:
+          LOOM_MAX_PREEMPTIONS: 2

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -60,28 +60,28 @@ fn insert_remove_local(c: &mut Criterion) {
                             start.wait();
                             let v: Vec<_> = (0..i).map(|i| slab.insert(i).unwrap()).collect();
                             for i in v {
-                                slab.take(i);
+                                slab.remove(i);
                             }
                         })
                         .thread(move |start, slab| {
                             start.wait();
                             let v: Vec<_> = (0..i).map(|i| slab.insert(i).unwrap()).collect();
                             for i in v {
-                                slab.take(i);
+                                slab.remove(i);
                             }
                         })
                         .thread(move |start, slab| {
                             start.wait();
                             let v: Vec<_> = (0..i).map(|i| slab.insert(i).unwrap()).collect();
                             for i in v {
-                                slab.take(i);
+                                slab.remove(i);
                             }
                         })
                         .thread(move |start, slab| {
                             start.wait();
                             let v: Vec<_> = (0..i).map(|i| slab.insert(i).unwrap()).collect();
                             for i in v {
-                                slab.take(i);
+                                slab.remove(i);
                             }
                         })
                         .run();
@@ -102,7 +102,7 @@ fn insert_remove_local(c: &mut Criterion) {
                             let v: Vec<_> =
                                 (0..i).map(|i| slab.write().unwrap().insert(i)).collect();
                             for i in v {
-                                slab.write().unwrap().take(i);
+                                slab.write().unwrap().remove(i);
                             }
                         })
                         .thread(move |start, slab| {
@@ -110,7 +110,7 @@ fn insert_remove_local(c: &mut Criterion) {
                             let v: Vec<_> =
                                 (0..i).map(|i| slab.write().unwrap().insert(i)).collect();
                             for i in v {
-                                slab.write().unwrap().take(i);
+                                slab.write().unwrap().remove(i);
                             }
                         })
                         .thread(move |start, slab| {
@@ -118,7 +118,7 @@ fn insert_remove_local(c: &mut Criterion) {
                             let v: Vec<_> =
                                 (0..i).map(|i| slab.write().unwrap().insert(i)).collect();
                             for i in v {
-                                slab.write().unwrap().take(i);
+                                slab.write().unwrap().remove(i);
                             }
                         })
                         .thread(move |start, slab| {
@@ -126,7 +126,7 @@ fn insert_remove_local(c: &mut Criterion) {
                             let v: Vec<_> =
                                 (0..i).map(|i| slab.write().unwrap().insert(i)).collect();
                             for i in v {
-                                slab.write().unwrap().take(i);
+                                slab.write().unwrap().remove(i);
                             }
                         })
                         .run();
@@ -151,7 +151,7 @@ fn insert_remove_single_thread(c: &mut Criterion) {
             b.iter(|| {
                 let v: Vec<_> = (0..i).map(|i| slab.insert(i).unwrap()).collect();
                 for i in v {
-                    slab.take(i);
+                    slab.remove(i);
                 }
             });
         });
@@ -160,7 +160,7 @@ fn insert_remove_single_thread(c: &mut Criterion) {
             b.iter(|| {
                 let v: Vec<_> = (0..i).map(|i| slab.insert(i)).collect();
                 for i in v {
-                    slab.take(i);
+                    slab.remove(i);
                 }
             });
         });
@@ -169,7 +169,7 @@ fn insert_remove_single_thread(c: &mut Criterion) {
             b.iter(|| {
                 let v: Vec<_> = (0..i).map(|i| slab.write().unwrap().insert(i)).collect();
                 for i in v {
-                    slab.write().unwrap().take(i);
+                    slab.write().unwrap().remove(i);
                 }
             });
         });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -735,4 +735,6 @@ impl<C: cfg::Config> Pack<C> for () {
 }
 
 #[cfg(test)]
+pub(crate) use self::tests::util as test_util;
+#[cfg(test)]
 mod tests;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,7 +212,7 @@ pub struct Slab<T, C: cfg::Config = DefaultConfig> {
 /// references is currently being accessed. If the item is removed from the slab
 /// while a guard exists, the removal will be deferred until all guards are dropped.
 pub struct Guard<'a, T, C: cfg::Config = DefaultConfig> {
-    inner: page::slot::Guard<'a, T>,
+    inner: page::slot::Guard<'a, T, C>,
     shard: &'a Shard<T, C>,
     key: usize,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,16 +174,12 @@ macro_rules! thread_local {
     ($($tts:tt)+) => { std::thread_local!{ $($tts)+ } }
 }
 
-#[cfg(test)]
 macro_rules! test_println {
     ($($arg:tt)*) => {
-        println!("{:?} {}", crate::Tid::<crate::DefaultConfig>::current(), format_args!($($arg)*))
+        if cfg!(test) {
+            println!("{:?} {}", crate::Tid::<crate::DefaultConfig>::current(), format_args!($($arg)*))
+        }
     }
-}
-
-#[cfg(not(test))]
-macro_rules! test_println {
-    ($($arg:tt)*) => {};
 }
 
 pub mod implementation;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,7 @@
 //!
 #![doc(html_root_url = "https://docs.rs/sharded-slab/0.0.3")]
 
+#[cfg(test)]
 macro_rules! thread_local {
     ($($tts:tt)+) => { loom::thread_local!{ $($tts)+ } }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,6 +174,7 @@ macro_rules! thread_local {
     ($($tts:tt)+) => { std::thread_local!{ $($tts)+ } }
 }
 
+#[cfg(test)]
 macro_rules! test_println {
     ($($arg:tt)*) => {
         println!("{:?} {}", crate::Tid::<crate::DefaultConfig>::current(), format_args!($($arg)*))
@@ -733,4 +734,5 @@ impl<C: cfg::Config> Pack<C> for () {
     }
 }
 
+#[cfg(test)]
 mod tests;

--- a/src/page/mod.rs
+++ b/src/page/mod.rs
@@ -314,6 +314,7 @@ impl<C: cfg::Config> Clone for Addr<C> {
 
 impl<C: cfg::Config> Copy for Addr<C> {}
 
+#[cfg(test)]
 mod test {
     use super::*;
     use crate::Pack;

--- a/src/page/mod.rs
+++ b/src/page/mod.rs
@@ -160,7 +160,7 @@ impl<T, C: cfg::Config> Shared<T, C> {
             let gen = slot.insert(t);
             local.set_head(slot.next());
             gen
-        });
+        })?;
 
         let index = head + self.prev_sz;
 
@@ -169,7 +169,7 @@ impl<T, C: cfg::Config> Shared<T, C> {
     }
 
     #[inline]
-    pub(crate) fn get(&self, addr: Addr<C>, idx: usize) -> Option<slot::Guard<'_, T>> {
+    pub(crate) fn get(&self, addr: Addr<C>, idx: usize) -> Option<slot::Guard<'_, T, C>> {
         let poff = addr.offset() - self.prev_sz;
 
         test_println!("-> offset {:?}", poff);

--- a/src/page/mod.rs
+++ b/src/page/mod.rs
@@ -1,8 +1,5 @@
 use crate::cfg::{self, CfgPrivate};
-use crate::sync::{
-    atomic::{spin_loop_hint, AtomicUsize, Ordering},
-    CausalCell,
-};
+use crate::sync::CausalCell;
 use crate::Pack;
 
 pub(crate) mod slot;

--- a/src/page/slot.rs
+++ b/src/page/slot.rs
@@ -212,14 +212,12 @@ impl<T, C: cfg::Config> Slot<T, C> {
         loop {
             let refs = self.refs.load(Ordering::Acquire);
 
-            print!("-> refs={:?}", refs);
-
             if refs & Lifecycle::REFS_MASK == 0 {
-                test_println!("; ok to remove!");
+                test_println!("-> refs={:#x}; ok to remove!", refs);
                 return self.item.with_mut(|item| unsafe { (*item).take() });
             }
 
-            test_println!("; spin");
+            test_println!("-> refs={:#x}; spin...", refs);
             atomic::spin_loop_hint();
         }
     }

--- a/src/page/slot.rs
+++ b/src/page/slot.rs
@@ -6,10 +6,7 @@ use crate::{cfg, Pack, Tid};
 use std::{fmt, marker::PhantomData};
 
 pub(crate) struct Slot<T, C> {
-    /// ABA guard generation counter incremented every time a value is inserted
-    /// into the slot.
-    gen: AtomicUsize,
-    refs: AtomicUsize,
+    lifecycle: AtomicUsize,
     /// The offset of the next item on the free list.
     next: CausalCell<usize>,
     /// The data stored in the slot.
@@ -18,9 +15,10 @@ pub(crate) struct Slot<T, C> {
 }
 
 #[derive(Debug)]
-pub(crate) struct Guard<'a, T> {
+pub(crate) struct Guard<'a, T, C = cfg::DefaultConfig> {
     item: &'a T,
-    refs: &'a AtomicUsize,
+    lifecycle: &'a AtomicUsize,
+    _cfg: PhantomData<fn(C)>,
 }
 
 #[repr(transparent)]
@@ -29,9 +27,22 @@ pub(crate) struct Generation<C = cfg::DefaultConfig> {
     _cfg: PhantomData<fn(C)>,
 }
 
+struct LifecycleGen<C>(Generation<C>);
+
+#[repr(transparent)]
+struct RefCount<C = cfg::DefaultConfig> {
+    value: usize,
+    _cfg: PhantomData<fn(C)>,
+}
+
+struct Lifecycle<C> {
+    state: State,
+    _cfg: PhantomData<fn(C)>,
+}
+
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 #[repr(usize)]
-enum Lifecycle {
+enum State {
     NotRemoved = 0b00,
     Marked = 0b01,
     Removing = 0b11,
@@ -68,8 +79,7 @@ impl<C: cfg::Config> Generation<C> {
 impl<T, C: cfg::Config> Slot<T, C> {
     pub(in crate::page) fn new(next: usize) -> Self {
         Self {
-            gen: AtomicUsize::new(0),
-            refs: AtomicUsize::new(0),
+            lifecycle: AtomicUsize::new(0),
             item: CausalCell::new(None),
             next: CausalCell::new(next),
             _cfg: PhantomData,
@@ -77,12 +87,12 @@ impl<T, C: cfg::Config> Slot<T, C> {
     }
 
     #[inline(always)]
-    pub(in crate::page) fn get(&self, gen: Generation<C>) -> Option<Guard<'_, T>> {
-        let mut lifecycle = self.refs.load(Ordering::Acquire);
+    pub(in crate::page) fn get(&self, gen: Generation<C>) -> Option<Guard<'_, T, C>> {
+        let mut lifecycle = self.lifecycle.load(Ordering::Acquire);
         loop {
-            let state = Lifecycle::from(lifecycle);
-
-            let current_gen = self.gen.load(Ordering::Acquire);
+            let state = Lifecycle::<C>::from_packed(lifecycle);
+            let current_gen = LifecycleGen::<C>::from_packed(lifecycle).0;
+            let refs = RefCount::<C>::from_packed(lifecycle);
 
             test_println!(
                 "-> get {:?}; current_gen={:?}; lifecycle={:#x}; state={:?}; refs={:?};",
@@ -90,34 +100,36 @@ impl<T, C: cfg::Config> Slot<T, C> {
                 current_gen,
                 lifecycle,
                 state,
-                lifecycle >> Lifecycle::REFS_SHIFT,
+                refs,
             );
 
             // Is the index's generation the same as the current generation? If not,
             // the item that index referred to was removed, so return `None`.
-            if gen.value != current_gen || state != Lifecycle::NotRemoved {
+            if gen != current_gen || state != Lifecycle::NOT_REMOVED {
+                test_println!("-> get: no longer exists!");
                 return None;
             }
 
-            let new_refs = lifecycle + 4;
-            match self.refs.compare_exchange(
+            let new_refs = refs.incr();
+            match self.lifecycle.compare_exchange(
                 lifecycle,
-                new_refs | state as usize,
+                new_refs.pack(current_gen.pack(state.pack(0))),
                 Ordering::AcqRel,
                 Ordering::Acquire,
             ) {
                 Ok(_) => {
                     let item = self.value()?;
 
-                    test_println!("-> {:?} + 1 refs", lifecycle >> Lifecycle::REFS_SHIFT,);
+                    test_println!("-> {:?}", new_refs);
 
                     return Some(Guard {
                         item,
-                        refs: &self.refs,
+                        lifecycle: &self.lifecycle,
+                        _cfg: PhantomData,
                     });
                 }
                 Err(actual) => {
-                    test_println!("-> retry; lifecycle={:#x};", actual);
+                    test_println!("-> get: retrying; lifecycle={:#x};", actual);
                     lifecycle = actual;
                 }
             };
@@ -130,28 +142,51 @@ impl<T, C: cfg::Config> Slot<T, C> {
     }
 
     #[inline]
-    pub(super) fn insert(&self, value: &mut Option<T>) -> Generation<C> {
+    pub(super) fn insert(&self, value: &mut Option<T>) -> Option<Generation<C>> {
         debug_assert!(
             self.item.with(|item| unsafe { (*item).is_none() }),
             "inserted into full slot"
         );
         debug_assert!(value.is_some(), "inserted twice");
 
-        // If the `is_removed` bit was not previously set, that's fine; this
-        // might have been removed via `remove_now`.
-        self.refs
-            .store(Lifecycle::NotRemoved as usize, Ordering::Release);
+        let lifecycle = self.lifecycle.load(Ordering::Acquire);
+        let gen = LifecycleGen::from_packed(lifecycle).0;
+        let refs = RefCount::<C>::from_packed(lifecycle);
+
+        test_println!(
+            "-> insert; state={:?}; gen={:?}; refs={:?}",
+            Lifecycle::<C>::from_packed(lifecycle),
+            gen,
+            refs
+        );
+        if refs.value != 0 {
+            test_println!("-> insert while referenced! cancelling");
+            return None;
+        }
+        let new_lifecycle = gen.pack(Lifecycle::<C>::NOT_REMOVED.pack(0));
+        if let Err(_actual) = self.lifecycle.compare_exchange(
+            lifecycle,
+            new_lifecycle,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        ) {
+            test_println!(
+                "-> modified during insert, cancelling! new={:#x}; expected={:#x}; actual={:#x};",
+                new_lifecycle,
+                lifecycle,
+                _actual
+            );
+            return None;
+        }
 
         // Set the new value.
         self.item.with_mut(|item| unsafe {
             *item = value.take();
         });
 
-        let gen = self.gen.load(Ordering::Acquire);
+        test_println!("-> inserted at {:?}", gen);
 
-        test_println!("-> {:?}", gen);
-
-        Generation::new(gen)
+        Some(gen)
     }
 
     #[inline(always)]
@@ -161,24 +196,55 @@ impl<T, C: cfg::Config> Slot<T, C> {
 
     #[inline]
     pub(super) fn remove(&self, gen: Generation<C>) -> bool {
-        let curr_gen = self.gen.load(Ordering::Acquire);
+        let mut lifecycle = self.lifecycle.load(Ordering::Acquire);
+        let mut curr_gen = LifecycleGen::from_packed(lifecycle).0;
+        let prev;
+        loop {
+            test_println!(
+                "-> remove deferred; gen={:?}; current_gen={:?};",
+                gen,
+                curr_gen
+            );
 
-        test_println!("-> remove deferred; gen={:?};", curr_gen);
+            // Is the slot still at the generation we are trying to remove?
+            if gen != curr_gen {
+                return false;
+            }
 
-        // Is the slot still at the generation we are trying to remove?
-        if gen.value != curr_gen {
-            return false;
+            let new_lifecycle = Lifecycle::<C>::MARKED.pack(lifecycle);
+            test_println!(
+                "-> remove deferred; old_lifecycle={:#x}; new_lifecycle={:#x};",
+                lifecycle,
+                new_lifecycle
+            );
+            match self.lifecycle.compare_exchange(
+                lifecycle,
+                new_lifecycle,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(actual) => {
+                    prev = actual;
+                    break;
+                }
+                Err(actual) => {
+                    test_println!("-> remove deferred; retrying");
+                    lifecycle = actual;
+                    curr_gen = LifecycleGen::from_packed(lifecycle).0;
+                }
+            }
         }
 
-        let prev = self
-            .refs
-            .fetch_or(Lifecycle::Marked as usize, Ordering::Release);
-
-        test_println!("-> remove deferred; marked, prev={:#2x};", prev);
+        let refs = RefCount::<C>::from_packed(prev);
+        test_println!(
+            "-> remove deferred; marked, prev={:#2x}; refs={:?};",
+            prev,
+            refs
+        );
 
         // Are there currently outstanding references to the slot? If so, it
         // will have to be removed when those references are dropped.
-        if prev & Lifecycle::REFS_MASK > 0 {
+        if refs.value > 0 {
             return true;
         }
 
@@ -192,49 +258,51 @@ impl<T, C: cfg::Config> Slot<T, C> {
     }
 
     #[inline]
-    fn remove_inner(&self, current_gen: usize) -> Option<T> {
-        let next_gen = (current_gen + 1) % Generation::<C>::BITS;
-
-        if let Err(_actual) =
-            self.gen
-                .compare_exchange(current_gen, next_gen, Ordering::AcqRel, Ordering::Acquire)
-        {
-            test_println!(
-                "-> already removed; actual_gen={:?}; previous={:?};",
-                _actual,
-                current_gen
-            );
-            return None;
-        }
-
-        test_println!("-> next generation={:?};", next_gen);
-
+    fn remove_inner(&self, current_gen: Generation<C>) -> Option<T> {
+        let mut lifecycle = self.lifecycle.load(Ordering::Acquire);
+        let mut advanced = false;
+        let next_gen = current_gen.advance();
         loop {
-            let refs = self.refs.load(Ordering::Acquire);
-
-            if refs & Lifecycle::REFS_MASK == 0 {
-                test_println!("-> refs={:#x}; ok to remove!", refs);
-                return self.item.with_mut(|item| unsafe { (*item).take() });
+            let gen = Generation::from_packed(lifecycle);
+            test_println!("-> remove_inner; lifecycle={:#x}; expected_gen={:?}; current_gen={:?}; next_gen={:?};",
+                lifecycle,
+                current_gen,
+                next_gen,
+                gen
+            );
+            if (!advanced) && gen != current_gen {
+                test_println!("-> already removed!");
+                return None;
             }
-
-            test_println!("-> refs={:#x}; spin...", refs);
-            atomic::spin_loop_hint();
+            match self.lifecycle.compare_exchange(
+                lifecycle,
+                next_gen.pack(lifecycle),
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(actual) => {
+                    advanced = true;
+                    let refs = RefCount::<C>::from_packed(actual);
+                    test_println!("-> advanced gen; lifecycle={:#x}; refs={:?};", actual, refs);
+                    if refs.value == 0 {
+                        test_println!("-> ok to remove!");
+                        return self.item.with_mut(|item| unsafe { (*item).take() });
+                    } else {
+                        test_println!("-> refs={:?}; spin...", refs);
+                        atomic::spin_loop_hint();
+                    }
+                }
+                Err(actual) => {
+                    test_println!("-> retrying; lifecycle={:#x};", actual);
+                    lifecycle = actual;
+                }
+            }
         }
     }
 
     #[inline]
     pub(super) fn remove_value(&self, gen: Generation<C>) -> Option<T> {
-        let current = self.gen.load(Ordering::Acquire);
-
-        test_println!("-> remove={:?}; current={:?};", gen, current);
-
-        // Is the index's generation the same as the current generation? If not,
-        // the item that index referred to was already removed.
-        if gen.value != current {
-            return None;
-        }
-
-        self.remove_inner(current)
+        self.remove_inner(gen)
     }
 
     #[inline(always)]
@@ -247,16 +315,28 @@ impl<T, C: cfg::Config> Slot<T, C> {
 
 impl<T, C: cfg::Config> fmt::Debug for Slot<T, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let lifecycle = self.lifecycle.load(Ordering::Relaxed);
         f.debug_struct("Slot")
-            .field("gen", &self.gen.load(Ordering::Relaxed))
+            .field("lifecycle", &format_args!("{:#x}", lifecycle))
+            .field("state", &Lifecycle::<C>::from_packed(lifecycle).state)
+            .field("gen", &LifecycleGen::<C>::from_packed(lifecycle).0)
+            .field("refs", &RefCount::<C>::from_packed(lifecycle))
             .field("next", &self.next())
             .finish()
     }
 }
 
+// === impl Generation ===
+
 impl<C> fmt::Debug for Generation<C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("Generation").field(&self.value).finish()
+    }
+}
+
+impl<C: cfg::Config> Generation<C> {
+    fn advance(self) -> Self {
+        Self::from_usize((self.value + 1) % Self::BITS)
     }
 }
 
@@ -288,23 +368,25 @@ impl<C: cfg::Config> Clone for Generation<C> {
 
 impl<C: cfg::Config> Copy for Generation<C> {}
 
-impl<'a, T> Guard<'a, T> {
+// === impl Guard ===
+
+impl<'a, T, C: cfg::Config> Guard<'a, T, C> {
     pub(crate) fn release(&self) -> bool {
-        let mut state = self.refs.load(Ordering::Relaxed);
+        let mut lifecycle = self.lifecycle.load(Ordering::Acquire);
         loop {
-            let refs = state >> Lifecycle::REFS_SHIFT;
-            let lifecycle = Lifecycle::from(state);
+            let refs = RefCount::<C>::from_packed(lifecycle);
+            let state = Lifecycle::<C>::from_packed(lifecycle).state;
             // if refs == 0 {
             //     #[cfg(test)]
             //     test_println!("drop on 0 refs; something is weird!");
             //     state = self.refs.load(Ordering::Acquire);
             //     continue;
             // }
-            let dropping = refs == 1 && lifecycle == Lifecycle::Marked;
+            let dropping = refs.value == 1 && state == State::Marked;
             let new_state = if dropping {
-                Lifecycle::Removing as usize
+                State::Removing as usize
             } else {
-                (refs - 1) << Lifecycle::REFS_SHIFT | lifecycle as usize
+                refs.decr().pack(lifecycle)
             };
 
             test_println!(
@@ -314,14 +396,23 @@ impl<'a, T> Guard<'a, T> {
                 new_state,
                 dropping
             );
-            match self
-                .refs
-                .compare_exchange(state, new_state, Ordering::Release, Ordering::Relaxed)
-            {
-                Ok(_) => return dropping,
+            match self.lifecycle.compare_exchange(
+                lifecycle,
+                new_state,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    test_println!(
+                        "-> drop guard: done; new_state={:#x}; dropping={:?}",
+                        new_state,
+                        dropping
+                    );
+                    return dropping;
+                }
                 Err(actual) => {
                     test_println!("-> drop guard; retry, actual={:?}", actual);
-                    state = actual;
+                    lifecycle = actual;
                 }
             }
         }
@@ -332,20 +423,134 @@ impl<'a, T> Guard<'a, T> {
     }
 }
 
-impl Lifecycle {
-    const MASK: usize = 0b11;
-    const REFS_MASK: usize = !Self::MASK;
-    const REFS_SHIFT: usize = cfg::WIDTH - (Self::MASK.leading_zeros() as usize);
+// === impl Lifecycle ===
+
+impl<C: cfg::Config> Lifecycle<C> {
+    const MARKED: Self = Self {
+        state: State::Marked,
+        _cfg: PhantomData,
+    };
+
+    const NOT_REMOVED: Self = Self {
+        state: State::NotRemoved,
+        _cfg: PhantomData,
+    };
 }
 
-impl From<usize> for Lifecycle {
-    #[inline(always)]
-    fn from(u: usize) -> Self {
-        match u & Self::MASK {
-            0b00 => Lifecycle::NotRemoved,
-            0b01 => Lifecycle::Marked,
-            0b11 => Lifecycle::Removing,
-            bad => unreachable!("weird lifecycle {:#b}", bad),
+impl<C: cfg::Config> Pack<C> for Lifecycle<C> {
+    const LEN: usize = 2;
+    type Prev = ();
+
+    fn from_usize(u: usize) -> Self {
+        Self {
+            state: match u & Self::MASK {
+                0b00 => State::NotRemoved,
+                0b01 => State::Marked,
+                0b11 => State::Removing,
+                bad => unreachable!("weird lifecycle {:#b}", bad),
+            },
+            _cfg: PhantomData,
         }
+    }
+
+    fn as_usize(&self) -> usize {
+        self.state as usize
+    }
+}
+
+impl<C> PartialEq for Lifecycle<C> {
+    fn eq(&self, other: &Self) -> bool {
+        self.state == other.state
+    }
+}
+
+impl<C> Eq for Lifecycle<C> {}
+
+impl<C> fmt::Debug for Lifecycle<C> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Lifecycle").field(&self.state).finish()
+    }
+}
+
+// === impl RefCount ===
+
+impl<C: cfg::Config> Pack<C> for RefCount<C> {
+    const LEN: usize = cfg::WIDTH - (Lifecycle::<C>::LEN + Generation::<C>::LEN);
+    type Prev = Lifecycle<C>;
+
+    fn from_usize(value: usize) -> Self {
+        debug_assert!(value <= Self::BITS);
+        Self {
+            value,
+            _cfg: PhantomData,
+        }
+    }
+
+    fn as_usize(&self) -> usize {
+        self.value
+    }
+}
+
+impl<C: cfg::Config> RefCount<C> {
+    const ONE: Self = Self {
+        value: 1,
+        _cfg: PhantomData,
+    };
+
+    fn incr(self) -> Self {
+        Self::from_usize((self.value + 1) % Self::BITS)
+    }
+
+    fn decr(self) -> Self {
+        Self::from_usize(self.value.saturating_sub(1))
+    }
+}
+
+impl<C> fmt::Debug for RefCount<C> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("RefCount").field(&self.value).finish()
+    }
+}
+
+impl<C: cfg::Config> PartialEq for RefCount<C> {
+    fn eq(&self, other: &Self) -> bool {
+        self.value == other.value
+    }
+}
+
+impl<C: cfg::Config> Eq for RefCount<C> {}
+
+impl<C: cfg::Config> PartialOrd for RefCount<C> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.value.partial_cmp(&other.value)
+    }
+}
+
+impl<C: cfg::Config> Ord for RefCount<C> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.value.cmp(&other.value)
+    }
+}
+
+impl<C: cfg::Config> Clone for RefCount<C> {
+    fn clone(&self) -> Self {
+        Self::from_usize(self.value)
+    }
+}
+
+impl<C: cfg::Config> Copy for RefCount<C> {}
+
+// === impl LifecycleGen ===
+
+impl<C: cfg::Config> Pack<C> for LifecycleGen<C> {
+    const LEN: usize = Generation::<C>::LEN;
+    type Prev = RefCount<C>;
+
+    fn from_usize(value: usize) -> Self {
+        Self(Generation::from_usize(value))
+    }
+
+    fn as_usize(&self) -> usize {
+        self.0.as_usize()
     }
 }

--- a/src/page/stack.rs
+++ b/src/page/stack.rs
@@ -1,5 +1,5 @@
 use crate::cfg;
-use crate::sync::atomic::{spin_loop_hint, AtomicUsize, Ordering};
+use crate::sync::atomic::{AtomicUsize, Ordering};
 use std::{fmt, marker::PhantomData};
 
 pub(super) struct TransferStack<C = cfg::DefaultConfig> {

--- a/src/page/stack.rs
+++ b/src/page/stack.rs
@@ -1,0 +1,101 @@
+use crate::cfg;
+use crate::sync::atomic::{spin_loop_hint, AtomicUsize, Ordering};
+use std::marker::PhantomData;
+
+#[derive(Debug)]
+pub(super) struct TransferStack<C: cfg::Config = cfg::DefaultConfig> {
+    head: AtomicUsize,
+    _cfg: PhantomData<fn(C)>,
+}
+
+impl<C: cfg::Config> TransferStack<C> {
+    pub(super) fn new() -> Self {
+        Self {
+            head: AtomicUsize::new(super::Addr::<C>::NULL),
+            _cfg: PhantomData,
+        }
+    }
+
+    pub(super) fn pop_all(&self) -> Option<usize> {
+        let val = self.head.swap(super::Addr::<C>::NULL, Ordering::Acquire);
+        test_println!("-> pop {:#x}", val);
+        if val == super::Addr::<C>::NULL {
+            None
+        } else {
+            Some(val)
+        }
+    }
+
+    pub(super) fn push(&self, value: usize) -> usize {
+        let mut next = self.head.load(Ordering::Relaxed);
+        loop {
+            test_println!("-> next {:#x}", next);
+
+            match self
+                .head
+                .compare_exchange(next, value, Ordering::AcqRel, Ordering::Acquire)
+            {
+                // lost the race!
+                Err(actual) => {
+                    test_println!("-> retry!");
+                    next = actual;
+                }
+                Ok(_) => {
+                    test_println!("-> successful; next={:#x}", next);
+                    return next;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{sync::CausalCell, test_util};
+    use loom::thread;
+    use std::sync::Arc;
+
+    #[test]
+    fn transfer_stack() {
+        test_util::run_model("transfer_stack", || {
+            let causalities = [CausalCell::new(999), CausalCell::new(999)];
+            let shared = Arc::new((causalities, TransferStack::<cfg::DefaultConfig>::new()));
+            let shared1 = shared.clone();
+            let shared2 = shared.clone();
+
+            let t1 = thread::spawn(move || {
+                let (causalities, stack) = &*shared1;
+                causalities[0].with_mut(|val| {
+                    stack.push(0);
+                    unsafe {
+                        *val = 0;
+                    }
+                })
+            });
+            let t2 = thread::spawn(move || {
+                let (causalities, stack) = &*shared2;
+                causalities[1].with_mut(|val| {
+                    stack.push(1);
+                    unsafe {
+                        *val = 1;
+                    }
+                })
+            });
+
+            let (causalities, stack) = &*shared;
+            let mut idx = stack.pop_all();
+            while idx == None {
+                idx = stack.pop_all();
+                thread::yield_now();
+            }
+            let idx = idx.unwrap();
+            causalities[idx].with_mut(|val| unsafe {
+                assert_eq!(*val, idx);
+            });
+
+            t1.join().unwrap();
+            t2.join().unwrap();
+        });
+    }
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -304,6 +304,7 @@ fn concurrent_remove_remote_and_reuse() {
 
         let s = slab.clone();
         let s2 = slab.clone();
+
         let t1 = thread::spawn(move || {
             s.take(idx1).expect("must remove");
         });
@@ -313,14 +314,12 @@ fn concurrent_remove_remote_and_reuse() {
         });
 
         let idx3 = store_when_free(&slab, 3);
-        let idx4 = store_when_free(&slab, 4);
         t1.join().expect("thread 1 should not panic");
         t2.join().expect("thread 1 should not panic");
 
         assert!(slab.get(idx1).is_none(), "slab: {:#?}", slab);
         assert!(slab.get(idx2).is_none(), "slab: {:#?}", slab);
         assert_eq!(slab.get(idx3).unwrap(), 3, "slab: {:#?}", slab);
-        assert_eq!(slab.get(idx4).unwrap(), 4, "slab: {:#?}", slab);
     });
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -43,24 +43,29 @@ impl crate::Config for TinyConfig {
     const INITIAL_PAGE_SIZE: usize = 4;
 }
 
-fn run_model(name: &'static str, f: impl Fn() + Sync + Send + 'static) {
-    run_builder(name, loom::model::Builder::new(), f)
-}
+use self::util::*;
+pub(super) mod util {
+    use super::*;
 
-fn run_builder(
-    name: &'static str,
-    builder: loom::model::Builder,
-    f: impl Fn() + Sync + Send + 'static,
-) {
-    let iters = AtomicUsize::new(1);
-    builder.check(move || {
-        test_println!(
-            "\n------------ running test {}; iteration {} ------------\n",
-            name,
-            iters.fetch_add(1, Ordering::SeqCst)
-        );
-        f()
-    });
+    pub(crate) fn run_model(name: &'static str, f: impl Fn() + Sync + Send + 'static) {
+        run_builder(name, loom::model::Builder::new(), f)
+    }
+
+    pub(crate) fn run_builder(
+        name: &'static str,
+        builder: loom::model::Builder,
+        f: impl Fn() + Sync + Send + 'static,
+    ) {
+        let iters = AtomicUsize::new(1);
+        builder.check(move || {
+            test_println!(
+                "\n------------ running test {}; iteration {} ------------\n",
+                name,
+                iters.fetch_add(1, Ordering::SeqCst)
+            );
+            f()
+        });
+    }
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -44,9 +44,17 @@ impl crate::Config for TinyConfig {
 }
 
 fn run_model(name: &'static str, f: impl Fn() + Sync + Send + 'static) {
-    let iters = AtomicUsize::new(0);
-    loom::model(move || {
-        println!(
+    run_builder(name, loom::model::Builder::new(), f)
+}
+
+fn run_builder(
+    name: &'static str,
+    builder: loom::model::Builder,
+    f: impl Fn() + Sync + Send + 'static,
+) {
+    let iters = AtomicUsize::new(1);
+    builder.check(move || {
+        test_println!(
             "\n------------ running test {}; iteration {} ------------\n",
             name,
             iters.fetch_add(1, Ordering::SeqCst)
@@ -200,7 +208,7 @@ fn concurrent_insert_take() {
         let remover = thread::spawn(move || {
             let (lock, cvar) = &*pair2;
             for i in 0..2 {
-                println!("--- remover i={} ---", i);
+                test_println!("--- remover i={} ---", i);
                 let mut next = lock.lock().unwrap();
                 while next.is_none() {
                     next = cvar.wait(next).unwrap();
@@ -213,7 +221,7 @@ fn concurrent_insert_take() {
 
         let (lock, cvar) = &*pair;
         for i in 0..2 {
-            println!("--- inserter i={} ---", i);
+            test_println!("--- inserter i={} ---", i);
             let key = slab.insert(i).expect("insert");
 
             let mut next = lock.lock().unwrap();
@@ -257,6 +265,60 @@ fn take_remote_and_reuse() {
 
         assert_eq!(slab.get(idx1).unwrap(), 5, "slab: {:#?}", slab);
         assert_eq!(slab.get(idx2).unwrap(), 2, "slab: {:#?}", slab);
+        assert_eq!(slab.get(idx3).unwrap(), 3, "slab: {:#?}", slab);
+        assert_eq!(slab.get(idx4).unwrap(), 4, "slab: {:#?}", slab);
+    });
+}
+
+fn store_when_free<C: crate::Config>(slab: &Arc<Slab<usize, C>>, t: usize) -> usize {
+    loop {
+        test_println!("try store {:?}", t);
+        if let Some(key) = slab.insert(t) {
+            test_println!("inserted at {:#x}", key);
+            return key;
+        }
+        test_println!("retrying; slab is full...");
+        thread::yield_now();
+    }
+}
+
+struct TinierConfig;
+
+impl crate::Config for TinierConfig {
+    const INITIAL_PAGE_SIZE: usize = 2;
+    const MAX_PAGES: usize = 1;
+}
+
+#[test]
+fn concurrent_remove_remote_and_reuse() {
+    let mut model = loom::model::Builder::new();
+    model.max_branches = 100000;
+    run_builder("concurrent_remove_remote_and_reuse", model, || {
+        let slab = Arc::new(Slab::new_with_config::<TinierConfig>());
+
+        let idx1 = slab.insert(1).unwrap();
+        let idx2 = slab.insert(2).unwrap();
+
+        assert_eq!(slab.get(idx1).unwrap(), 1, "slab: {:#?}", slab);
+        assert_eq!(slab.get(idx2).unwrap(), 2, "slab: {:#?}", slab);
+
+        let s = slab.clone();
+        let s2 = slab.clone();
+        let t1 = thread::spawn(move || {
+            s.take(idx1).expect("must remove");
+        });
+
+        let t2 = thread::spawn(move || {
+            s2.take(idx2).expect("must remove");
+        });
+
+        let idx3 = store_when_free(&slab, 3);
+        let idx4 = store_when_free(&slab, 4);
+        t1.join().expect("thread 1 should not panic");
+        t2.join().expect("thread 1 should not panic");
+
+        assert!(slab.get(idx1).is_none(), "slab: {:#?}", slab);
+        assert!(slab.get(idx2).is_none(), "slab: {:#?}", slab);
         assert_eq!(slab.get(idx3).unwrap(), 3, "slab: {:#?}", slab);
         assert_eq!(slab.get(idx4).unwrap(), 4, "slab: {:#?}", slab);
     });
@@ -409,7 +471,7 @@ fn custom_page_sz() {
         let slab = Slab::<usize>::new_with_config::<TinyConfig>();
 
         for i in 0..1024usize {
-            println!("{}", i);
+            test_println!("{}", i);
             let k = slab.insert(i).expect("insert");
             let v = slab.get(k).expect("get");
             assert_eq!(v, i, "slab: {:#?}", slab);

--- a/src/tid.rs
+++ b/src/tid.rs
@@ -109,7 +109,7 @@ impl<C> fmt::Debug for Tid<C> {
                 .finish()
         } else {
             f.debug_tuple("Tid")
-                .field(&format_args!("{:#x}", self.id))
+                .field(&format_args!("{}", self.id))
                 .finish()
         }
     }


### PR DESCRIPTION
This change moves all the per-slot shared state (generation, ref count, 
and removal state) into a single `AtomicUsize`. This has several 
advantages:

* It reduces the overall complexity of the `Slot` type, as it no longer
  depends on the complex interactions of multiple atomics. The loom
  tests are now _much_ faster (which is also a nice sign of relative 
  complexity, IMO), and the code is easier to reason about.
* All interactions with the generation will now involve a RMW. Even
  when the generation is not being modified, we will always perform a
  read-modify-write with that generation to update _some_ part of the
  state (such as the ref count or removal state). If this RMW fails
  because our view of the generation is stale, we'll re-acquire the 
  state, and see that the generation has changed. This will ensure 
  that the generation counter actually guards against reads with a
  a stale generation.
* Generation ops need no longer be sequentially consistent.
* Slots are a word smaller :)

There isn't really any noticeable performance impact before/after. The
"after" benchmarks are generally about ~2-5% faster across the board,
but I'm not sure if this is really significant (even though Criterion
*claims* it is).