### PR TITLE
 fix: `remove` not adding slots to free lists 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ harness = false
 lazy_static = "1"
 
 [dev-dependencies]
-loom = { version = "0.2", features = ["checkpoint"] }
+loom = { version = "0.2" }
 proptest = "0.9.4"
 criterion = "0.3"
 slab = "0.4.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,7 +177,7 @@ macro_rules! thread_local {
 
 macro_rules! test_println {
     ($($arg:tt)*) => {
-        if cfg!(test) || cfg!(slab_print) {
+        if cfg!(test) && cfg!(slab_print) {
             println!("{:?} {}", crate::Tid::<crate::DefaultConfig>::current(), format_args!($($arg)*))
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,8 +177,8 @@ macro_rules! thread_local {
 
 macro_rules! test_println {
     ($($arg:tt)*) => {
-        if cfg!(test) {
-            println!("{:?} {}", crate::Tid::<crate::DefaultConfig>::current(), format_args!($($arg)*))
+        if cfg!(test) || cfg!(slab_print) {
+            eprintln!("{:?} {}", crate::Tid::<crate::DefaultConfig>::current(), format_args!($($arg)*))
         }
     }
 }
@@ -505,7 +505,7 @@ impl<T, C: cfg::Config> Shard<T, C> {
     }
 
     #[inline(always)]
-    fn page_indices(idx: usize) -> (page::Addr<C>, usize) {
+    pub(crate) fn page_indices(idx: usize) -> (page::Addr<C>, usize) {
         let addr = C::unpack_addr(idx);
         (addr, addr.index())
     }

--- a/src/page/mod.rs
+++ b/src/page/mod.rs
@@ -314,7 +314,7 @@ impl<C: cfg::Config> Clone for Addr<C> {
 impl<C: cfg::Config> Copy for Addr<C> {}
 
 #[inline(always)]
-pub(crate) fn indices<C: cfg::Config>(idx: usize) -> (page::Addr<C>, usize) {
+pub(crate) fn indices<C: cfg::Config>(idx: usize) -> (Addr<C>, usize) {
     let addr = C::unpack_addr(idx);
     (addr, addr.index())
 }

--- a/src/page/mod.rs
+++ b/src/page/mod.rs
@@ -313,6 +313,12 @@ impl<C: cfg::Config> Clone for Addr<C> {
 
 impl<C: cfg::Config> Copy for Addr<C> {}
 
+#[inline(always)]
+pub(crate) fn indices<C: cfg::Config>(idx: usize) -> (page::Addr<C>, usize) {
+    let addr = C::unpack_addr(idx);
+    (addr, addr.index())
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -482,3 +482,27 @@ fn custom_page_sz() {
         }
     });
 }
+
+#[test]
+fn free_list_is_used() {
+    struct TinyConfig;
+
+    impl crate::cfg::Config for TinyConfig {
+        const INITIAL_PAGE_SIZE: usize = 2;
+    }
+
+    run_model("free_list_is_used", || {
+        let slab = Slab::new_with_config::<TinyConfig>();
+
+        let t1 = slab.insert("hello").expect("insert");
+        let t2 = slab.insert("world").expect("insert");
+        assert_eq!(super::Shard::<&str, TinyConfig>::page_indices(t1).1, 0);
+        assert_eq!(super::Shard::<&str, TinyConfig>::page_indices(t2).1, 0);
+        let t3 = slab.insert("earth").expect("insert");
+        assert_eq!(super::Shard::<&str, TinyConfig>::page_indices(t3).1, 1);
+        slab.remove(t2);
+
+        let t4 = slab.insert("universe").expect("insert");
+        assert_eq!(super::Shard::<&str, TinyConfig>::page_indices(t4).1, 0);
+    });
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -498,18 +498,38 @@ mod free_list_reuse {
 
             let t1 = slab.insert("hello").expect("insert");
             let t2 = slab.insert("world").expect("insert");
-            assert_eq!(crate::Shard::<&str, TinyConfig>::page_indices(t1).1, 0);
-            assert_eq!(crate::Shard::<&str, TinyConfig>::page_indices(t2).1, 0);
+            assert_eq!(
+                crate::page::indices::<TinyConfig>(t1).1,
+                0,
+                "1st slot should be on 0th page"
+            );
+            assert_eq!(
+                crate::page::indices::<TinyConfig>(t2).1,
+                0,
+                "2nd slot should be on 0th page"
+            );
             let t3 = slab.insert("earth").expect("insert");
-            assert_eq!(crate::Shard::<&str, TinyConfig>::page_indices(t3).1, 1);
+            assert_eq!(
+                crate::page::indices::<TinyConfig>(t3).1,
+                1,
+                "3rd slot should be on 1st page"
+            );
 
             slab.remove(t2);
             let t4 = slab.insert("universe").expect("insert");
-            assert_eq!(crate::Shard::<&str, TinyConfig>::page_indices(t4).1, 0);
+            assert_eq!(
+                crate::page::indices::<TinyConfig>(t4).1,
+                0,
+                "2nd slot should be reused (0th page)"
+            );
 
             slab.remove(t1);
-            let t5 = slab.insert("goodbye").expect("insert");
-            assert_eq!(crate::Shard::<&str, TinyConfig>::page_indices(t4).1, 0);
+            let _ = slab.insert("goodbye").expect("insert");
+            assert_eq!(
+                crate::page::indices::<TinyConfig>(t4).1,
+                0,
+                "1st slot should be reused (0th page)"
+            );
         });
     }
 
@@ -520,18 +540,38 @@ mod free_list_reuse {
 
             let t1 = slab.insert("hello").expect("insert");
             let t2 = slab.insert("world").expect("insert");
-            assert_eq!(crate::Shard::<&str, TinyConfig>::page_indices(t1).1, 0);
-            assert_eq!(crate::Shard::<&str, TinyConfig>::page_indices(t2).1, 0);
+            assert_eq!(
+                crate::page::indices::<TinyConfig>(t1).1,
+                0,
+                "1st slot should be on 0th page"
+            );
+            assert_eq!(
+                crate::page::indices::<TinyConfig>(t2).1,
+                0,
+                "2nd slot should be on 0th page"
+            );
             let t3 = slab.insert("earth").expect("insert");
-            assert_eq!(crate::Shard::<&str, TinyConfig>::page_indices(t3).1, 1);
+            assert_eq!(
+                crate::page::indices::<TinyConfig>(t3).1,
+                1,
+                "3rd slot should be on 1st page"
+            );
 
             assert_eq!(slab.take(t2), Some("world"));
             let t4 = slab.insert("universe").expect("insert");
-            assert_eq!(crate::Shard::<&str, TinyConfig>::page_indices(t4).1, 0);
+            assert_eq!(
+                crate::page::indices::<TinyConfig>(t4).1,
+                0,
+                "2nd slot should be reused (0th page)"
+            );
 
             assert_eq!(slab.take(t1), Some("hello"));
-            let t5 = slab.insert("goodbye").expect("insert");
-            assert_eq!(crate::Shard::<&str, TinyConfig>::page_indices(t4).1, 0);
+            let _ = slab.insert("goodbye").expect("insert");
+            assert_eq!(
+                crate::page::indices::<TinyConfig>(t4).1,
+                0,
+                "1st slot should be reused (0th page)"
+            );
         });
     }
 }


### PR DESCRIPTION
This fixes an issue where, when a slot is freed immediately by a call to
`remove` while uncontended, it was not added to the page's free list,
and thus never reused. This resulted in a memory leak.

I've also refactored some internals.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>