### PR TITLE
improve reference count validation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -421,8 +421,9 @@ impl<T, C: cfg::Config> Slab<T, C> {
 
     /// Return a reference to the value associated with the given key.
     ///
-    /// If the slab does not contain a value for the given key, `None` is
-    /// returned instead.
+    /// If the slab does not contain a value for the given key, or if the
+    /// maximum number of concurrent references to the slot has been reached,
+    /// `None` is returned instead.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
* fix: incorrect wrapping when overflowing maximum ref count

  Currently, when the maximum reference count for a slot is reached, the
  reference count wraps to 0. This is wrong, as it could potentially cause
  a use-after-free by allowing the slot to be released while there are
  still active references.

  This commit fixes this by adding a check in `Slot::get` that creating a
  new reference would not overflow the reference count. If the reference
  count would overflow, `get` returns `None` instead. Additionally, I've
  added debug assertions that ensure this check works correctly.

  I've also added a new test for this.

  Fixes #22

* feat(Config): validate concurrent refs

  This commit adds a check in `Config::validate` that there can be at
  least 2 concurrent references to a slot. Otherwise...what's the point?

  Fixes #21