### PR TITLE
Improve spinning in `Slot::take`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -366,10 +366,17 @@ impl<T, C: cfg::Config> Slab<T, C> {
     /// If the slab does not contain a value for that key, `None` is returned
     /// instead.
     ///
-    /// **Note**: If the value associated with the given key is currently being
+    /// If the value associated with the given key is currently being
     /// accessed by another thread, this method will block the current thread
     /// until the item is no longer accessed. If this is not desired, use
     /// [`remove`] instead.
+    ///
+    /// **Note**: This method blocks the calling thread by spinning until the
+    /// currently outstanding references are released. Spinning for long periods
+    /// of time can result in high CPU time and power consumption. Therefore,
+    /// `take` should only be called when other references to the slot are
+    /// expected to be dropped soon (e.g., when all accesses are relatively
+    /// short).
     ///
     /// # Examples
     ///

--- a/src/page/slot.rs
+++ b/src/page/slot.rs
@@ -283,6 +283,8 @@ impl<T, C: cfg::Config> Slot<T, C> {
     ) -> Option<T> {
         let mut lifecycle = self.lifecycle.load(Ordering::Acquire);
         let mut advanced = false;
+        // Exponential spin backoff while waiting for the slot to be released.
+        let mut spin_exp = 0;
         let next_gen = gen.advance();
         loop {
             let current_gen = Generation::from_packed(lifecycle);
@@ -292,6 +294,7 @@ impl<T, C: cfg::Config> Slot<T, C> {
                 current_gen,
                 next_gen
             );
+
             // First, make sure we are actually able to remove the value.
             // If we're going to remove the value, the generation has to match
             // the value that `remove_value` was called with...unless we've
@@ -300,6 +303,7 @@ impl<T, C: cfg::Config> Slot<T, C> {
                 test_println!("-> already removed!");
                 return None;
             }
+
             match self.lifecycle.compare_exchange(
                 lifecycle,
                 next_gen.pack(lifecycle),
@@ -324,11 +328,15 @@ impl<T, C: cfg::Config> Slot<T, C> {
                     // Otherwise, a reference must be dropped before we can
                     // remove the value. Spin here until there are no refs remaining...
                     test_println!("-> refs={:?}; spin...", refs);
-                    atomic::spin_loop_hint();
+
+                    // Back off, spinning and possibly yielding.
+                    exponential_backoff(&mut spin_exp);
                 }
                 Err(actual) => {
                     test_println!("-> retrying; lifecycle={:#x};", actual);
                     lifecycle = actual;
+                    // The state changed; reset the spin backoff.
+                    spin_exp = 0;
                 }
             }
         }
@@ -579,5 +587,27 @@ impl<C: cfg::Config> Pack<C> for LifecycleGen<C> {
 
     fn as_usize(&self) -> usize {
         self.0.as_usize()
+    }
+}
+
+// === helpers ===
+
+#[inline(always)]
+fn exponential_backoff(exp: &mut usize) {
+    /// Maximum exponent we can back off to.
+    const MAX_EXPONENT: usize = 8;
+
+    // Issue 2^exp pause instructions.
+    for _ in 0..(1 << *exp) {
+        atomic::spin_loop_hint();
+    }
+
+    if *exp >= MAX_EXPONENT {
+        // If we have reached the max backoff, also yield to the scheduler
+        // explicitly.
+        crate::sync::yield_now();
+    } else {
+        // Otherwise, increment the exponent.
+        *exp += 1;
     }
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -7,12 +7,15 @@ mod inner {
         pub use loom::sync::atomic::*;
         pub use std::sync::atomic::Ordering;
     }
+
+    pub(crate) use loom::thread::yield_now;
 }
 
 #[cfg(not(test))]
 mod inner {
     use std::cell::UnsafeCell;
     pub(crate) use std::sync::atomic;
+    pub(crate) use std::thread::yield_now;
 
     #[derive(Debug)]
     pub struct CausalCell<T>(UnsafeCell<T>);


### PR DESCRIPTION
* feat(Slab::take): add exponential backoff when spinning
  
  `Slab::take` will spin if there are currently outstanding references to
  the `take`n slot. Spinning is not the ideal way to block a thread until
  a state changes, since it uses CPU time that might be used by other
  threads, and impacts power consumption. However, waiting "properly"
  (e.g. with a condvar) here is difficult. If we wanted to give each slot
  a `Mutex` and `Condvar` pair, we would need two heap allocations per
  slot (assuming POSIX `pthread_mutex` and `pthread_cond`), plus 16 bytes
  for the Rust `std::sync::Mutex` and `std::sync::Condvar` types. This is
  a lot of additional per-slot overhead.
  
  As a compromise, this commit updates `take` to spin with an exponential
  backoff. Now, every time `take` spins, it will issue an exponentially
  increasing number of `std::sync::atomic::spin_loop_hint` calls (on x86,
  probably a `pause` instruction), up to 256. Once the backoff has
  increased to 256, it will also explicitly yield to the scheduler.
  Although this is not as good as actually parking the thread until the
  state changes, it doesn't require the allocations of the mutex/condvar
  pair, and should make the spin loop a little less hot.
  
* docs(Slab::take): document that `take` spins
  
  This commit updates the API docs for `Slab::take` to note explicitly
  that the calling thread is blocked by spinning until outstanding
  references to the removed slot are dropped. The docs now warn against
  using `take` if references to a slot may last for a long time, and note
  that it should only be used when such references are relatively
  short-lived.
  
  Fixes #20