### PR TITLE
docs(Pool): Add documentation for `Pool`

### DIFF
--- a/src/clear.rs
+++ b/src/clear.rs
@@ -1,14 +1,14 @@
 use std::{collections, hash, ops::DerefMut, sync};
 
+/// Clear all data in `self`, retaining the allocated capacithy.
+///
+/// # Note
+///
+/// This should only be implemented for types whose clear operation *retains
+/// any allocations* for that type. Types such as `BTreeMap`, whose
+/// `clear()` method releases the existing allocation, should *not*
+/// implement this trait.
 pub trait Clear {
-    /// Clear all data in `self`, retaining the allocated capacithy.
-    ///
-    /// # Note
-    ///
-    /// This should only be implemented for types whose clear operation *retains
-    /// any allocations* for that type. Types such as `BTreeMap`, whose
-    /// `clear()` method releases the existing allocation, should *not*
-    /// implement this trait.
     fn clear(&mut self);
 }
 

--- a/src/clear.rs
+++ b/src/clear.rs
@@ -6,8 +6,9 @@ use std::{collections, hash, ops::DerefMut, sync};
 /// This is essentially a generalization of methods on standard library
 /// collection types, including as [`Vec::clear`], [`String::clear`], and
 /// [`HashMap::clear`]. These methods drop all data stored in the collection,
-/// but retain the collection's heap allocation for future use. Types such as `BTreeMap` whose
-/// `clear` methods drops allocations should not implement this trait.
+/// but retain the collection's heap allocation for future use. Types such as
+/// `BTreeMap`, whose `clear` methods drops allocations, should not 
+/// implement this trait.
 ///
 /// When implemented for types which do not own a heap allocation, `Clear`
 /// should reset the type in place if possible. If the type has an empty state

--- a/src/clear.rs
+++ b/src/clear.rs
@@ -6,7 +6,8 @@ use std::{collections, hash, ops::DerefMut, sync};
 /// This is essentially a generalization of methods on standard library
 /// collection types, including as [`Vec::clear`], [`String::clear`], and
 /// [`HashMap::clear`]. These methods drop all data stored in the collection,
-/// but retain the collection's heap allocation for future use.
+/// but retain the collection's heap allocation for future use. Types such as `BTreeMap` whose
+/// `clear` methods drops allocations should not implement this trait.
 ///
 /// When implemented for types which do not own a heap allocation, `Clear`
 /// should reset the type in place if possible. If the type has an empty state

--- a/src/clear.rs
+++ b/src/clear.rs
@@ -1,14 +1,26 @@
 use std::{collections, hash, ops::DerefMut, sync};
 
-/// Clear all data in `self`, retaining the allocated capacithy.
+/// Trait implemented by types which can be cleared in place, retaining any
+/// allocated memory.
 ///
-/// # Note
+/// This is essentially a generalization of methods on standard library
+/// collection types, including as [`Vec::clear`], [`String::clear`], and
+/// [`HashMap::clear`]. These methods drop all data stored in the collection,
+/// but retain the collection's heap allocation for future use.
 ///
-/// This should only be implemented for types whose clear operation *retains
-/// any allocations* for that type. Types such as `BTreeMap`, whose
-/// `clear()` method releases the existing allocation, should *not*
-/// implement this trait.
+/// When implemented for types which do not own a heap allocation, `Clear`
+/// should reset the type in place if possible. If the type has an empty state
+/// or stores `Option`s, those values should be reset to the empty state. For
+/// "plain old data" types, which hold no pointers to other data and do not have
+/// an empty or initial state, it's okay for a `Clear` implementation to be a
+/// no-op. In that case, it essentially serves as a marker indicating that the
+/// type may be reused to store new data.
+///
+/// [`Vec::clear`]: https://doc.rust-lang.org/stable/std/vec/struct.Vec.html#method.clear
+/// [`String::clear`]: https://doc.rust-lang.org/stable/std/string/struct.String.html#method.clear
+/// [`HashMap::clear`]: https://doc.rust-lang.org/stable/std/collections/struct.HashMap.html#method.clear
 pub trait Clear {
+    /// Clear all data in `self`, retaining the allocated capacithy.
     fn clear(&mut self);
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,7 +186,7 @@ macro_rules! test_println {
 mod clear;
 pub mod implementation;
 mod page;
-pub(crate) mod pool;
+mod pool;
 pub(crate) mod sync;
 mod tid;
 pub(crate) use tid::Tid;
@@ -195,8 +195,8 @@ mod iter;
 mod shard;
 use cfg::CfgPrivate;
 pub use cfg::{Config, DefaultConfig};
-pub use pool::Pool;
 pub use clear::Clear;
+pub use pool::{Pool, PoolGuard};
 
 use shard::Shard;
 use std::{fmt, marker::PhantomData};
@@ -427,11 +427,7 @@ impl<T, C: cfg::Config> Slab<T, C> {
             )
         })?;
 
-        Some(Guard {
-            inner,
-            shard,
-            key,
-        })
+        Some(Guard { inner, shard, key })
     }
 
     /// Returns `true` if the slab contains a value for the given key.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,7 +186,7 @@ macro_rules! test_println {
 mod clear;
 pub mod implementation;
 mod page;
-pub mod pool;
+pub(crate) mod pool;
 pub(crate) mod sync;
 mod tid;
 pub(crate) use tid::Tid;
@@ -195,8 +195,8 @@ mod iter;
 mod shard;
 use cfg::CfgPrivate;
 pub use cfg::{Config, DefaultConfig};
-
 pub use pool::Pool;
+pub use clear::Clear;
 
 use shard::Shard;
 use std::{fmt, marker::PhantomData};

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -10,9 +10,9 @@ use std::{fmt, marker::PhantomData};
 
 /// A lock-free concurrent object pool.
 ///
-/// Slabs provide pre-allocated storage for many instances of a single type. But when working with
-/// heap allocated objects, the advantages of a slab are lost as the memory allocated for the
-/// object is freed when the object is removed from the slab. With a pool, we can instead re-use
+/// Slabs provide pre-allocated storage for many instances of a single type. But, when working with
+/// heap allocated objects, the advantages of a slab are lost, as the memory allocated for the
+/// object is freed when the object is removed from the slab. With a pool, we can instead reuse
 /// this memory for objects being added to the pool in the future, therefore reducing memory
 /// fragmentation and avoiding additional allocations.
 ///
@@ -35,18 +35,19 @@ use std::{fmt, marker::PhantomData};
 /// assert_eq!(pool.get(key).unwrap(), String::from("hello world"));
 /// ```
 ///
-/// Pool entries can be cleared either by manually calling [`Pool::clear`] or when the guard is
-/// dropped. The entry will be cleared when all the references to it are dropped.
+/// Pool entries can be cleared either by manually calling [`Pool::clear`]. This marks the entry to
+/// be cleared when the guards referencing to it are dropped.
 /// ```
 /// # use sharded_slab::Pool;
-/// # use std::thread;
-/// # use std::sync::Arc;
 /// let pool: Pool<String> = Pool::new();
 ///
 /// let key = pool.create(|item| item.push_str("hello world")).unwrap();
 ///
 /// // Mark this entry to be cleared.
 /// pool.clear(key);
+///
+/// // The cleared entry is no longer available in the pool
+/// assert!(pool.get(key).is_none());
 /// ```
 /// # Configuration
 ///


### PR DESCRIPTION
Add type level documentation for `Pool`. Update exports to include `clear::Clear` and clean them up.