### PR TITLE
test: update loom, CI improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
         with:
           command: check
           args: --all-features
+          
   test:
     name: test
     runs-on: ubuntu-latest
@@ -19,12 +20,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@master
-      - uses: actions-rs/cargo@v1
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
         with:
-          command: test
-          args: --all-features
-        env:
-          LOOM_MAX_PREEMPTIONS: 2
+          toolchain: nightly
+          override: true
+
+      - name: Run tests
+        run: ./bin/loom.sh
 
   clippy_check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,18 @@ jobs:
   check:
     name: check
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - nightly
     steps:
       - uses: actions/checkout@master
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: ${{ matrix.rust }}
           override: true
       - name: Cargo check
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - uses: actions-rs/cargo@v1
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Cargo check
+        uses: actions-rs/cargo@v1
         with:
           command: check
           args: --all-features
-          
+
   test:
     name: test
     runs-on: ubuntu-latest
@@ -24,9 +31,9 @@ jobs:
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
+          profile: minimal
           toolchain: nightly
           override: true
-
       - name: Run tests
         run: ./bin/loom.sh
 
@@ -35,9 +42,16 @@ jobs:
     needs: check
 
     steps:
-      - uses: actions/checkout@v1
-      - run: rustup component add clippy
-      - uses: actions-rs/clippy-check@v1
+      - uses: actions/checkout@v2
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: clippy
+          override: true
+      - name: Run clippy
+        uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features
@@ -48,8 +62,16 @@ jobs:
     needs: check
 
     steps:
-      - uses: actions/checkout@master
-      - uses: actions-rs/cargo@v1
+      - uses: actions/checkout@v2
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: rustfmt
+          override: true
+      - name: Run rustfmt
+        uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ harness = false
 lazy_static = "1"
 
 [dev-dependencies]
-loom = { version = "0.2" }
+loom = { version = "0.3", features = ["checkpoint"] }
 proptest = "0.9.4"
 criterion = "0.3"
 slab = "0.4.2"

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Most implementations of lock-free data structures in Rust require some
 amount of unsafe code, and this crate is not an exception. In order to catch
 potential bugs in this unsafe code, we make use of [`loom`], a
 permutation-testing tool for concurrent Rust programs. All `unsafe` blocks
-this crate occur in accesses to `loom` `CausalCell`s. This means that when
+this crate occur in accesses to `loom` `UnsafeCell`s. This means that when
 those accesses occur in this crate's tests, `loom` will assert that they are
 valid under the C11 memory model across multiple permutations of concurrent
 executions of those tests.

--- a/bin/loom.sh
+++ b/bin/loom.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Runs Loom tests with defaults for Loom's configuration values.
+#
+# The nightly Rust compiler is used to enable Loom's location tracking support.
+# This allows Loom to emit diagnostics that include the caller's source code
+# locations when errors occur. 
+#
+# The tests are compiled in release mode to improve performance, but debug
+# assertions are enabled. 
+#
+# Any arguments to this script are passed to the `cargo test` invocation.
+
+RUSTFLAGS="${RUSTFLAGS} --cfg loom_nightly -C debug-assertions=on" \
+    LOOM_MAX_PREEMPTIONS="${LOOM_MAX_PREEMPTIONS:-2}" \
+    LOOM_CHECKPOINT_INTERVAL="${LOOM_CHECKPOINT_INTERVAL:-1}" \
+    LOOM_LOG=1 \
+    LOOM_LOCATION=1 \
+    cargo +nightly test --release "$@"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@
 //! amount of unsafe code, and this crate is not an exception. In order to catch
 //! potential bugs in this unsafe code, we make use of [`loom`], a
 //! permutation-testing tool for concurrent Rust programs. All `unsafe` blocks
-//! this crate occur in accesses to `loom` `CausalCell`s. This means that when
+//! this crate occur in accesses to `loom` `UnsafeCell`s. This means that when
 //! those accesses occur in this crate's tests, `loom` will assert that they are
 //! valid under the C11 memory model across multiple permutations of concurrent
 //! executions of those tests.

--- a/src/page/mod.rs
+++ b/src/page/mod.rs
@@ -1,6 +1,6 @@
 use crate::cfg::{self, CfgPrivate};
 use crate::clear::Clear;
-use crate::sync::CausalCell;
+use crate::sync::UnsafeCell;
 use crate::Pack;
 
 pub(crate) mod slot;
@@ -70,7 +70,7 @@ pub(crate) type Iter<'a, T, C> = std::iter::FilterMap<
 
 pub(crate) struct Local {
     /// Index of the first slot on the local free list
-    head: CausalCell<usize>,
+    head: UnsafeCell<usize>,
 }
 
 pub(crate) struct Shared<T, C> {
@@ -85,7 +85,7 @@ pub(crate) struct Shared<T, C> {
     // then there are no slots left in that page.
     size: usize,
     prev_sz: usize,
-    slab: CausalCell<Option<Slots<T, C>>>,
+    slab: UnsafeCell<Option<Slots<T, C>>>,
 }
 
 type Slots<T, C> = Box<[Slot<T, C>]>;
@@ -93,7 +93,7 @@ type Slots<T, C> = Box<[Slot<T, C>]>;
 impl Local {
     pub(crate) fn new() -> Self {
         Self {
-            head: CausalCell::new(0),
+            head: UnsafeCell::new(0),
         }
     }
 
@@ -128,7 +128,7 @@ where
             prev_sz,
             size,
             remote: stack::TransferStack::new(),
-            slab: CausalCell::new(None),
+            slab: UnsafeCell::new(None),
         }
     }
 

--- a/src/page/slot.rs
+++ b/src/page/slot.rs
@@ -1,7 +1,7 @@
 use super::FreeList;
 use crate::sync::{
     atomic::{self, AtomicUsize, Ordering},
-    CausalCell,
+    UnsafeCell,
 };
 use crate::{cfg, clear::Clear, Pack, Tid};
 use std::{fmt, marker::PhantomData};
@@ -9,9 +9,9 @@ use std::{fmt, marker::PhantomData};
 pub(crate) struct Slot<T, C> {
     lifecycle: AtomicUsize,
     /// The offset of the next item on the free list.
-    next: CausalCell<usize>,
+    next: UnsafeCell<usize>,
     /// The data stored in the slot.
-    item: CausalCell<T>,
+    item: UnsafeCell<T>,
     _cfg: PhantomData<fn(C)>,
 }
 
@@ -417,8 +417,8 @@ where
     pub(in crate::page) fn new(next: usize) -> Self {
         Self {
             lifecycle: AtomicUsize::new(0),
-            item: CausalCell::new(T::default()),
-            next: CausalCell::new(next),
+            item: UnsafeCell::new(T::default()),
+            next: UnsafeCell::new(next),
             _cfg: PhantomData,
         }
     }

--- a/src/page/stack.rs
+++ b/src/page/stack.rs
@@ -72,14 +72,14 @@ impl<C> fmt::Debug for TransferStack<C> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{sync::CausalCell, test_util};
+    use crate::{sync::UnsafeCell, test_util};
     use loom::thread;
     use std::sync::Arc;
 
     #[test]
     fn transfer_stack() {
         test_util::run_model("transfer_stack", || {
-            let causalities = [CausalCell::new(999), CausalCell::new(999)];
+            let causalities = [UnsafeCell::new(999), UnsafeCell::new(999)];
             let shared = Arc::new((causalities, TransferStack::<cfg::DefaultConfig>::new()));
             let shared1 = shared.clone();
             let shared2 = shared.clone();
@@ -113,7 +113,7 @@ mod test {
             causalities[idx].with(|val| unsafe {
                 assert_eq!(
                     *val, idx,
-                    "CausalCell write must happen-before index is pushed to the stack!"
+                    "UnsafeCell write must happen-before index is pushed to the stack!"
                 );
             });
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -2,7 +2,7 @@ pub(crate) use self::inner::*;
 
 #[cfg(test)]
 mod inner {
-    pub(crate) use loom::sync::CausalCell;
+    pub(crate) use loom::cell::UnsafeCell;
     pub(crate) mod atomic {
         pub use loom::sync::atomic::*;
         pub use std::sync::atomic::Ordering;
@@ -13,16 +13,15 @@ mod inner {
 
 #[cfg(not(test))]
 mod inner {
-    use std::cell::UnsafeCell;
     pub(crate) use std::sync::atomic;
     pub(crate) use std::thread::yield_now;
 
     #[derive(Debug)]
-    pub struct CausalCell<T>(UnsafeCell<T>);
+    pub struct UnsafeCell<T>(std::cell::UnsafeCell<T>);
 
-    impl<T> CausalCell<T> {
-        pub fn new(data: T) -> CausalCell<T> {
-            CausalCell(UnsafeCell::new(data))
+    impl<T> UnsafeCell<T> {
+        pub fn new(data: T) -> UnsafeCell<T> {
+            UnsafeCell(std::cell::UnsafeCell::new(data))
         }
 
         #[inline(always)]


### PR DESCRIPTION
This branch updates `loom`to 0.3, adds a shell script (`bin/loom.sh`), 
which runs Loom tests with default values for Loom's configuration
variables, and makes a few minor CI tweaks to improve performance
by installing smaller Rust toolchains.

The nightly Rust compiler is used to enable Loom's location tracking
support. This allows Loom to emit diagnostics that include the caller's
source code locations when errors occur. For example, after modifying
the code to cause an invalid concurrent mutable access, we get nice
panics like this:

```
---- pool::tests::concurrent_create_clear stdout ----

 ================== Iteration 1 ==================

~~~~~~~~ THREAD 1 ~~~~~~~~
thread 'pool::tests::concurrent_create_clear' panicked at '
Causality violation: Concurrent write accesses to `UnsafeCell`.
      created: src/page/mod.rs:131:19
    write one: thread #0 @ src/page/mod.rs:188:9
    write two: thread #1 @ src/page/mod.rs:188:9
', ...
```

The tests are compiled in release mode to improve performance, but debug
assertions are enabled.

Any arguments to this script are passed to the `cargo test` invocation.


Fixes #23