### PR TITLE
feat(Pool): unify guard types

### DIFF
--- a/src/page/mod.rs
+++ b/src/page/mod.rs
@@ -223,27 +223,6 @@ where
         })
     }
 
-    pub(crate) fn remove<F: FreeList<C>>(
-        &self,
-        addr: Addr<C>,
-        gen: slot::Generation<C>,
-        free_list: &F,
-    ) -> bool {
-        let offset = addr.offset() - self.prev_sz;
-
-        test_println!("-> offset {:?}", offset);
-
-        self.slab.with(|slab| {
-            let slab = unsafe { &*slab }.as_ref();
-            if let Some(slot) = slab.and_then(|slab| slab.get(offset)) {
-                slot.try_remove_value(gen, offset, free_list);
-                true
-            } else {
-                false
-            }
-        })
-    }
-
     // Need this function separately, as we need to pass a function pointer to `filter_map` and
     // `Slot::value` just returns a `&T`, specifically a `&Option<T>` for this impl.
     fn make_ref(slot: &'a Slot<Option<T>, C>) -> Option<&'a T> {

--- a/src/page/slot.rs
+++ b/src/page/slot.rs
@@ -376,27 +376,6 @@ where
         Some(gen)
     }
 
-    /// Tries to remove the value in the slot
-    ///
-    /// This method tries to remove the value in the slot. If there are existing references, then
-    /// the slot is marked for removal and the next thread calling either this method or
-    /// `remove_value` will do the work instead.
-    #[inline]
-    pub(super) fn try_remove_value<F: FreeList<C>>(
-        &self,
-        gen: Generation<C>,
-        offset: usize,
-        free: &F,
-    ) -> Option<T> {
-        if self.mark_release(gen) {
-            None
-        } else {
-            // Otherwise, we can remove the slot now!
-            test_println!("-> try_remove_value; can remove now");
-            self.remove_value(gen, offset, free)
-        }
-    }
-
     #[inline]
     pub(super) fn remove_value<F: FreeList<C>>(
         &self,

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -4,6 +4,7 @@ use crate::{
     page,
     tid::Tid,
     Pack, Shard,
+    Guard
 };
 
 use std::{fmt, marker::PhantomData};
@@ -162,14 +163,14 @@ where
     /// assert_eq!(pool.get(key).unwrap(), String::from("hello world"));
     /// assert!(pool.get(12345).is_none());
     /// ```
-    pub fn get(&self, key: usize) -> Option<PoolGuard<'_, T, C>> {
+    pub fn get(&self, key: usize) -> Option<Guard<'_, T, C>> {
         let tid = C::unpack_tid(key);
 
         test_println!("pool: get{:?}; current={:?}", tid, Tid::<C>::current());
         let shard = self.shards.get(tid.as_usize())?;
         let inner = shard.get(key, |x| x)?;
 
-        Some(PoolGuard { inner, shard, key })
+        Some(Guard { inner, shard, key })
     }
 
     /// Remove the value using the storage associated with the given key from the pool, returning

--- a/src/shard.rs
+++ b/src/shard.rs
@@ -108,29 +108,6 @@ where
         shared.take(addr, C::unpack_gen(idx), shared.free_list())
     }
 
-    pub(crate) fn remove_local(&self, idx: usize) -> bool {
-        debug_assert_eq!(Tid::<C>::from_packed(idx).as_usize(), self.tid);
-        let (addr, page_index) = page::indices::<C>(idx);
-
-        if page_index > self.shared.len() {
-            return false;
-        }
-
-        self.shared[page_index].remove(addr, C::unpack_gen(idx), self.local(page_index))
-    }
-
-    pub(crate) fn remove_remote(&self, idx: usize) -> bool {
-        debug_assert_eq!(Tid::<C>::from_packed(idx).as_usize(), self.tid);
-        let (addr, page_index) = page::indices::<C>(idx);
-
-        if page_index > self.shared.len() {
-            return false;
-        }
-
-        let shared = &self.shared[page_index];
-        shared.remove(addr, C::unpack_gen(idx), shared.free_list())
-    }
-
     pub(crate) fn iter<'a>(&'a self) -> std::slice::Iter<'a, page::Shared<Option<T>, C>> {
         self.shared.iter()
     }


### PR DESCRIPTION
Begin unification of guard types by using common code paths for
clearing an entry.

Closes #30 