### PR TITLE
chore: prepare to release 0.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+<a name="0.0.9"></a>
+### 0.0.9 (2020-04-03)
+
+
+#### Features
+
+* **Config:**  validate concurrent refs ([9b32af58](9b32af58), closes [#21](21))
+* **Pool:**
+  *  add `fmt::Debug` impl for `Pool` ([ffa5c7a0](ffa5c7a0))
+  *  add `Default` impl for `Pool` ([d2399365](d2399365))
+  *  add a sharded object pool for reusing heap allocations (#19) ([89734508](89734508), closes [#2](2), [#15](15))
+* **Slab::take:**  add exponential backoff when spinning ([6b743a27](6b743a27))
+
+#### Bug Fixes
+
+*   incorrect wrapping when overflowing maximum ref count ([aea693f3](aea693f3), closes [#22](22))
+
+
+
 <a name="0.0.8"></a>
 ### 0.0.8 (2020-01-31)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "sharded-slab"
-version = "0.0.8"
+version = "0.0.9"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
 edition = "2018"
-documentation = "https://docs.rs/sharded-slab/0.0.8/sharded_slab"
+documentation = "https://docs.rs/sharded-slab/0.0.9/sharded_slab"
 homepage = "https://github.com/hawkw/sharded-slab"
 repository = "https://github.com/hawkw/sharded-slab"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A lock-free concurrent slab.
 [crates-badge]: https://img.shields.io/crates/v/sharded-slab.svg
 [crates-url]: https://crates.io/crates/sharded-slab
 [docs-badge]: https://docs.rs/sharded-slab/badge.svg
-[docs-url]: https://docs.rs/sharded-slab/0.0.8/sharded_slab
+[docs-url]: https://docs.rs/sharded-slab/0.0.9/sharded_slab
 [ci-badge]: https://github.com/hawkw/sharded-slab/workflows/CI/badge.svg
 [ci-url]: https://github.com/hawkw/sharded-slab/actions?workflow=CI
 [license-badge]: https://img.shields.io/crates/l/sharded-slab
@@ -35,7 +35,7 @@ optimization, and there may still be some lurking bugs.
 First, add this to your `Cargo.toml`:
 
 ```toml
-sharded-slab = "0.0.8"
+sharded-slab = "0.0.9"
 ```
 
 This crate provides two  types, [`Slab`] and [`Pool`], which provide slightly
@@ -57,12 +57,12 @@ _data_ they store, but retaining any previously-allocated capacity. This
 means that a [`Pool`] may be used to reuse a set of existing heap
 allocations, reducing allocator load.
 
-[`Slab`]: https://docs.rs/sharded-slab/0.0.8/sharded_slab/struct.Slab.html
-[inserting]: https://docs.rs/sharded-slab/0.0.8/sharded_slab/struct.Slab.html#method.insert
-[taking]: https://docs.rs/sharded-slab/0.0.8/sharded_slab/struct.Slab.html#method.take
-[`Pool`]: https://docs.rs/sharded-slab/0.0.8/sharded_slab/struct.Pool.html
-[create]: https://docs.rs/sharded-slab/0.0.8/sharded_slab/struct.Pool.html#method.create
-[cleared]: https://docs.rs/sharded-slab/0.0.8/sharded_slab/trait.Clear.html
+[`Slab`]: https://docs.rs/sharded-slab/0.0.9/sharded_slab/struct.Slab.html
+[inserting]: https://docs.rs/sharded-slab/0.0.9/sharded_slab/struct.Slab.html#method.insert
+[taking]: https://docs.rs/sharded-slab/0.0.9/sharded_slab/struct.Slab.html#method.take
+[`Pool`]: https://docs.rs/sharded-slab/0.0.9/sharded_slab/struct.Pool.html
+[create]: https://docs.rs/sharded-slab/0.0.9/sharded_slab/struct.Pool.html#method.create
+[cleared]: https://docs.rs/sharded-slab/0.0.9/sharded_slab/trait.Clear.html
 [object pool]: https://en.wikipedia.org/wiki/Object_pool_pattern
 
 ### Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //! First, add this to your `Cargo.toml`:
 //!
 //! ```toml
-//! sharded-slab = "0.0.8"
+//! sharded-slab = "0.0.9"
 //! ```
 //!
 //! This crate provides two  types, [`Slab`] and [`Pool`], which provide


### PR DESCRIPTION

<a name="0.0.9"></a>
### 0.0.9 (2020-04-03)


#### Features

* **Config:**  validate concurrent refs ([9b32af58](9b32af58), closes [#21](21))
* **Pool:**
  *  add `fmt::Debug` impl for `Pool` ([ffa5c7a0](ffa5c7a0))
  *  add `Default` impl for `Pool` ([d2399365](d2399365))
  *  add a sharded object pool for reusing heap allocations (#19) ([89734508](89734508), closes [#2](2), [#15](15))
* **Slab::take:**  add exponential backoff when spinning ([6b743a27](6b743a27))

#### Bug Fixes

*   incorrect wrapping when overflowing maximum ref count ([aea693f3](aea693f3), closes [#22](22))

Signed-off-by: Eliza Weisman <eliza@buoyant.io>