### PR TITLE
feat(Crate): Add support for guards with arbitrary lifetimes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,7 +237,6 @@ pub use pool::{Pool, PoolGuard};
 use shard::Shard;
 use std::{fmt, marker::PhantomData, sync::Arc};
 
-
 /// A sharded slab.
 ///
 /// See the [crate-level documentation](index.html) for details on using this type.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -582,6 +582,14 @@ impl<T, C: cfg::Config> Drop for OwnedSlabGuard<T, C> {
     }
 }
 
+impl<T, C: cfg::Config> std::ops::Deref for OwnedSlabGuard<T, C> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.inner.item()
+    }
+}
+
 impl<'a, T, C> fmt::Debug for Guard<'a, T, C>
 where
     T: fmt::Debug,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,7 +256,7 @@ pub struct Guard<'a, T, C: cfg::Config = DefaultConfig> {
     key: usize,
 }
 
-pub struct OwnedSlabGuard<T, C : cfg::Config = DefaultConfig> {
+pub struct OwnedSlabGuard<T, C: cfg::Config = DefaultConfig> {
     inner: page::slot::OwnedGuard<T>,
     slab: Arc<Slab<T, C>>,
     key: usize,
@@ -279,7 +279,7 @@ impl<T> Slab<T> {
     }
 }
 
-impl<T, C: cfg::Config = DefaultConfig> Slab<T, C> {
+impl<T, C: cfg::Config> Slab<T, C> {
     fn get_owned(self: &Arc<Self>, key: usize) -> Option<OwnedSlabGuard<T>> {
         let tid = C::unpack_tid(key);
 

--- a/src/page/mod.rs
+++ b/src/page/mod.rs
@@ -202,11 +202,7 @@ where
         let poff = addr.offset() - self.prev_sz;
         let guard = self.get(addr, idx, f)?;
 
-        self.slab.with(|slab| {
-            let slot = unsafe { &*slab }.as_ref()?.get(poff)?;
-
-            Some(self::slot::into_owned_guard(guard))
-        })
+        Some(guard.into_owned_guard())
     }
 
     #[inline(always)]

--- a/src/page/mod.rs
+++ b/src/page/mod.rs
@@ -198,8 +198,7 @@ where
         addr: Addr<C>,
         idx: usize,
         f: impl FnOnce(&T) -> &U,
-    ) -> Option<slot::OwnedGuard<U>> {
-        let poff = addr.offset() - self.prev_sz;
+    ) -> Option<slot::OwnedGuard<U, C>> {
         let guard = self.get(addr, idx, f)?;
 
         Some(guard.into_owned_guard())

--- a/src/page/mod.rs
+++ b/src/page/mod.rs
@@ -193,6 +193,22 @@ where
         })
     }
 
+    pub(crate) fn get_owned<U>(
+        &self,
+        addr: Addr<C>,
+        idx: usize,
+        f: impl FnOnce(&T) -> &U,
+    ) -> Option<slot::OwnedGuard<U>> {
+        let poff = addr.offset() - self.prev_sz;
+        let guard = self.get(addr, idx, f)?;
+
+        self.slab.with(|slab| {
+            let slot = unsafe { &*slab }.as_ref()?.get(poff)?;
+
+            Some(self::slot::into_owned_guard(guard))
+        })
+    }
+
     #[inline(always)]
     pub(crate) fn free_list(&self) -> &impl FreeList<C> {
         &self.remote

--- a/src/page/slot.rs
+++ b/src/page/slot.rs
@@ -630,6 +630,10 @@ impl<T, C: cfg::Config> OwnedGuard<T, C> {
             }
         }
     }
+
+    pub(crate) fn item(&self) -> &T {
+        unsafe { self.item.as_ref() }
+    }
 }
 
 // === impl Lifecycle ===

--- a/src/page/slot.rs
+++ b/src/page/slot.rs
@@ -23,9 +23,10 @@ pub(crate) struct Guard<'a, T, C = cfg::DefaultConfig> {
 }
 
 #[derive(Debug)]
-pub(crate) struct OwnedGuard<T> {
+pub(crate) struct OwnedGuard<T, C = cfg::DefaultConfig> {
     item: NonNull<T>,
     lifecycle: NonNull<AtomicUsize>,
+    _cfg: PhantomData<fn(C)>
 }
 
 #[repr(transparent)]
@@ -95,11 +96,6 @@ where
     #[inline(always)]
     pub(super) fn value(&self) -> &T {
         self.item.with(|item| unsafe { &*item })
-    }
-
-    #[inline(always)]
-    pub(super) fn lifecycle(&self) -> &AtomicUsize {
-        &self.lifecycle
     }
 
     #[inline(always)]
@@ -575,10 +571,11 @@ impl<'a, T, C: cfg::Config> Guard<'a, T, C> {
         }
     }
 
-    pub(crate) fn into_owned_guard(self) -> OwnedGuard<T> {
+    pub(crate) fn into_owned_guard(self) -> OwnedGuard<T, C> {
         OwnedGuard {
             item: self.item.into(),
             lifecycle: self.lifecycle.into(),
+            _cfg: PhantomData
         }
     }
 

--- a/src/page/slot.rs
+++ b/src/page/slot.rs
@@ -4,7 +4,7 @@ use crate::sync::{
     UnsafeCell,
 };
 use crate::{cfg, clear::Clear, Pack, Tid};
-use std::{fmt, marker::PhantomData, ptr::NonNull };
+use std::{fmt, marker::PhantomData, ptr::NonNull};
 
 pub(crate) struct Slot<T, C> {
     lifecycle: AtomicUsize,
@@ -79,15 +79,6 @@ impl<C: cfg::Config> Generation<C> {
             value,
             _cfg: PhantomData,
         }
-    }
-}
-
-pub(crate) fn into_owned_guard<T, C: cfg::Config>(
-    guard: Guard<'_, T, C>,
-) -> OwnedGuard<T> {
-    OwnedGuard {
-        item: guard.item.into(),
-        lifecycle: guard.lifecycle.into()
     }
 }
 
@@ -581,6 +572,13 @@ impl<'a, T, C: cfg::Config> Guard<'a, T, C> {
                     lifecycle = actual;
                 }
             }
+        }
+    }
+
+    pub(crate) fn into_owned_guard(self) -> OwnedGuard<T> {
+        OwnedGuard {
+            item: self.item.into(),
+            lifecycle: self.lifecycle.into(),
         }
     }
 

--- a/src/page/slot.rs
+++ b/src/page/slot.rs
@@ -588,7 +588,7 @@ impl<'a, T, C: cfg::Config> Guard<'a, T, C> {
 
 impl<T, C: cfg::Config> OwnedGuard<T, C> {
     pub(crate) fn release(&self) -> bool {
-        let mut lifecycle = unsafe {  self.lifecycle.as_ref() }.load(Ordering::Acquire);
+        let mut lifecycle = unsafe { self.lifecycle.as_ref() }.load(Ordering::Acquire);
         loop {
             let refs = RefCount::<C>::from_packed(lifecycle);
             let state = Lifecycle::<C>::from_packed(lifecycle).state;

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     clear::Clear,
     page,
     tid::Tid,
-    Pack, Shard
+    Pack, Shard,
 };
 
 use std::{fmt, marker::PhantomData, sync::Arc};
@@ -322,7 +322,11 @@ where
     }
 }
 
-impl<T, C> Drop for OwnedPoolGuard<T, C> where T: Clear + Default, C: cfg::Config {
+impl<T, C> Drop for OwnedPoolGuard<T, C>
+where
+    T: Clear + Default,
+    C: cfg::Config,
+{
     fn drop(&mut self) {
         use crate::sync::atomic;
         test_println!(" -> drop OwnedPoolGuard: clearing data");
@@ -333,7 +337,11 @@ impl<T, C> Drop for OwnedPoolGuard<T, C> where T: Clear + Default, C: cfg::Confi
     }
 }
 
-impl<T, C> std::ops::Deref for OwnedPoolGuard<T, C> where T: Clear + Default, C: cfg::Config {
+impl<T, C> std::ops::Deref for OwnedPoolGuard<T, C>
+where
+    T: Clear + Default,
+    C: cfg::Config,
+{
     type Target = T;
 
     fn deref(&self) -> &Self::Target {

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -333,6 +333,14 @@ impl<T, C> Drop for OwnedPoolGuard<T, C> where T: Clear + Default, C: cfg::Confi
     }
 }
 
+impl<T, C> std::ops::Deref for OwnedPoolGuard<T, C> where T: Clear + Default, C: cfg::Config {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.inner.item()
+    }
+}
+
 impl<'a, T, C> fmt::Debug for PoolGuard<'a, T, C>
 where
     T: fmt::Debug + Clear + Default,

--- a/src/shard.rs
+++ b/src/shard.rs
@@ -68,7 +68,7 @@ where
         &self,
         idx: usize,
         f: impl FnOnce(&T) -> &U,
-    ) -> Option<page::slot::OwnedGuard<U>> {
+    ) -> Option<page::slot::OwnedGuard<U, C>> {
         debug_assert_eq!(Tid::<C>::from_packed(idx).as_usize(), self.tid);
         let (addr, page_index) = page::indices::<C>(idx);
 

--- a/src/shard.rs
+++ b/src/shard.rs
@@ -64,6 +64,22 @@ where
         self.shared[page_index].get(addr, idx, f)
     }
 
+    pub(crate) fn get_owned<U>(
+        &self,
+        idx: usize,
+        f: impl FnOnce(&T) -> &U,
+    ) -> Option<page::slot::OwnedGuard<U>> {
+        debug_assert_eq!(Tid::<C>::from_packed(idx).as_usize(), self.tid);
+        let (addr, page_index) = page::indices::<C>(idx);
+
+        test_println!("-> {:?}", addr);
+        if page_index > self.shared.len() {
+            return None;
+        }
+
+        self.shared[page_index].get_owned(addr, idx, f)
+    }
+
     pub(crate) fn new(tid: usize) -> Self {
         let mut total_sz = 0;
         let shared = (0..C::MAX_PAGES)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -114,8 +114,8 @@ fn take_local() {
 }
 
 mod owned_guard {
-    use std::sync::Arc;
     use super::*;
+    use std::sync::Arc;
 
     #[test]
     fn store_guard_on_heap() {


### PR DESCRIPTION
This commit adds types for supporting guards with arbitrary lifetimes.
The new `OwnedGuard` inner guard type holds `NonNull` pointers to the
item and lifecycle. This is safe as the API is only available when
`Slab`/`Pool` is wrapped in an `Arc`

