### PR TITLE
test: misc. test cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           args: --all-features
 
   test:
-    name: test
+    name: Tests
     runs-on: ubuntu-latest
     needs: check
 
@@ -40,6 +40,23 @@ jobs:
           toolchain: nightly
           override: true
       - name: Run tests
+        run: cargo test
+
+  test-loom:
+    name: Loom tests
+    runs-on: ubuntu-latest
+    needs: check
+
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - name: Run Loom tests
         run: ./bin/loom.sh
 
   clippy_check:

--- a/bin/loom.sh
+++ b/bin/loom.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Runs Loom tests with defaults for Loom's configuration values.
 #
 # The nightly Rust compiler is used to enable Loom's location tracking support.

--- a/bin/loom.sh
+++ b/bin/loom.sh
@@ -10,7 +10,7 @@
 #
 # Any arguments to this script are passed to the `cargo test` invocation.
 
-RUSTFLAGS="${RUSTFLAGS} --cfg loom_nightly -C debug-assertions=on" \
+RUSTFLAGS="${RUSTFLAGS} --cfg loom loom_nightly -C debug-assertions=on" \
     LOOM_MAX_PREEMPTIONS="${LOOM_MAX_PREEMPTIONS:-2}" \
     LOOM_CHECKPOINT_INTERVAL="${LOOM_CHECKPOINT_INTERVAL:-1}" \
     LOOM_LOG=1 \

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -161,7 +161,7 @@ impl<C: Config> fmt::Debug for DebugConfig<C> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_util::*, Slab};
+    use crate::Slab;
 
     #[test]
     #[should_panic]
@@ -177,8 +177,6 @@ mod tests {
             const MAX_PAGES: usize = 1;
         }
 
-        run_model("validates_max_refs", || {
-            let _slab = Slab::<usize>::new_with_config::<GiantGenConfig>();
-        })
+        let _slab = Slab::<usize>::new_with_config::<GiantGenConfig>();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -647,7 +647,7 @@ impl<C: cfg::Config> Pack<C> for () {
     }
 }
 
-#[cfg(test)]
+#[cfg(loom)]
 pub(crate) use self::tests::util as test_util;
 #[cfg(test)]
 mod tests;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,24 +201,19 @@
 //!
 #![doc(html_root_url = "https://docs.rs/sharded-slab/0.0.3")]
 
-#[cfg(test)]
-macro_rules! thread_local {
-    ($($tts:tt)+) => { loom::thread_local!{ $($tts)+ } }
-}
-
-#[cfg(not(test))]
-macro_rules! thread_local {
-    ($($tts:tt)+) => { std::thread_local!{ $($tts)+ } }
-}
-
 macro_rules! test_println {
     ($($arg:tt)*) => {
         if cfg!(test) && cfg!(slab_print) {
-            println!("[{:?} {}:{}] {}", crate::Tid::<crate::DefaultConfig>::current(), file!(), line!(), format_args!($($arg)*))
+            if std::thread::panicking() {
+                // getting the thread ID while panicking doesn't seem to play super nicely with loom's
+                // mock lazy_static...
+                println!("[PANIC {:>17}:{:<3}] {}", file!(), line!(), format_args!($($arg)*))
+            } else {
+                println!("[{:?} {:>17}:{:<3}] {}", crate::Tid::<crate::DefaultConfig>::current(), file!(), line!(), format_args!($($arg)*))
+            }
         }
     }
 }
-
 mod clear;
 pub mod implementation;
 mod page;

--- a/src/page/stack.rs
+++ b/src/page/stack.rs
@@ -69,7 +69,7 @@ impl<C> fmt::Debug for TransferStack<C> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(loom, test))]
 mod test {
     use super::*;
     use crate::{sync::UnsafeCell, test_util};

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -320,6 +320,3 @@ where
         *self.inner.item() == *other
     }
 }
-
-#[cfg(test)]
-mod tests;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -7,14 +7,19 @@ mod inner {
         pub use loom::sync::atomic::*;
         pub use std::sync::atomic::Ordering;
     }
-
+    pub(crate) use loom::lazy_static;
+    pub(crate) use loom::sync::Mutex;
     pub(crate) use loom::thread::yield_now;
+    pub(crate) use loom::thread_local;
 }
 
 #[cfg(not(test))]
 mod inner {
+    pub(crate) use lazy_static::lazy_static;
     pub(crate) use std::sync::atomic;
+    pub(crate) use std::sync::Mutex;
     pub(crate) use std::thread::yield_now;
+    pub(crate) use std::thread_local;
 
     #[derive(Debug)]
     pub struct UnsafeCell<T>(std::cell::UnsafeCell<T>);

--- a/src/tests/loom_pool.rs
+++ b/src/tests/loom_pool.rs
@@ -1,8 +1,5 @@
-use crate::{
-    clear::Clear,
-    tests::{util::*, TinyConfig},
-    Pack, Pool,
-};
+use super::util::*;
+use crate::{clear::Clear, Pack, Pool};
 use loom::{
     sync::{
         atomic::{AtomicBool, Ordering},

--- a/src/tests/loom_slab.rs
+++ b/src/tests/loom_slab.rs
@@ -1,73 +1,7 @@
+use super::util::*;
 use crate::Slab;
 use loom::sync::{Arc, Condvar, Mutex};
 use loom::thread;
-
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-
-mod idx {
-    use crate::{
-        cfg,
-        page::{self, slot},
-        Pack, Tid,
-    };
-    use proptest::prelude::*;
-
-    proptest! {
-        #[test]
-        fn tid_roundtrips(tid in 0usize..Tid::<cfg::DefaultConfig>::BITS) {
-            let tid = Tid::<cfg::DefaultConfig>::from_usize(tid);
-            let packed = tid.pack(0);
-            assert_eq!(tid, Tid::from_packed(packed));
-        }
-
-        #[test]
-        fn idx_roundtrips(
-            tid in 0usize..Tid::<cfg::DefaultConfig>::BITS,
-            gen in 0usize..slot::Generation::<cfg::DefaultConfig>::BITS,
-            addr in 0usize..page::Addr::<cfg::DefaultConfig>::BITS,
-        ) {
-            let tid = Tid::<cfg::DefaultConfig>::from_usize(tid);
-            let gen = slot::Generation::<cfg::DefaultConfig>::from_usize(gen);
-            let addr = page::Addr::<cfg::DefaultConfig>::from_usize(addr);
-            let packed = tid.pack(gen.pack(addr.pack(0)));
-            assert_eq!(addr, page::Addr::from_packed(packed));
-            assert_eq!(gen, slot::Generation::from_packed(packed));
-            assert_eq!(tid, Tid::from_packed(packed));
-        }
-    }
-}
-
-pub(crate) struct TinyConfig;
-
-impl crate::Config for TinyConfig {
-    const INITIAL_PAGE_SIZE: usize = 4;
-}
-
-use self::util::*;
-pub(super) mod util {
-    use super::*;
-
-    pub(crate) fn run_model(name: &'static str, f: impl Fn() + Sync + Send + 'static) {
-        run_builder(name, loom::model::Builder::new(), f)
-    }
-
-    pub(crate) fn run_builder(
-        name: &'static str,
-        builder: loom::model::Builder,
-        f: impl Fn() + Sync + Send + 'static,
-    ) {
-        let iters = AtomicUsize::new(1);
-        builder.check(move || {
-            test_println!(
-                "\n------------ running test {}; iteration {} ------------\n",
-                name,
-                iters.fetch_add(1, Ordering::SeqCst)
-            );
-            f()
-        });
-    }
-}
-
 #[test]
 fn take_local() {
     run_model("take_local", || {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,0 +1,68 @@
+#[cfg(not(loom))]
+mod idx {
+    use crate::{
+        cfg,
+        page::{self, slot},
+        Pack, Tid,
+    };
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn tid_roundtrips(tid in 0usize..Tid::<cfg::DefaultConfig>::BITS) {
+            let tid = Tid::<cfg::DefaultConfig>::from_usize(tid);
+            let packed = tid.pack(0);
+            assert_eq!(tid, Tid::from_packed(packed));
+        }
+
+        #[test]
+        fn idx_roundtrips(
+            tid in 0usize..Tid::<cfg::DefaultConfig>::BITS,
+            gen in 0usize..slot::Generation::<cfg::DefaultConfig>::BITS,
+            addr in 0usize..page::Addr::<cfg::DefaultConfig>::BITS,
+        ) {
+            let tid = Tid::<cfg::DefaultConfig>::from_usize(tid);
+            let gen = slot::Generation::<cfg::DefaultConfig>::from_usize(gen);
+            let addr = page::Addr::<cfg::DefaultConfig>::from_usize(addr);
+            let packed = tid.pack(gen.pack(addr.pack(0)));
+            assert_eq!(addr, page::Addr::from_packed(packed));
+            assert_eq!(gen, slot::Generation::from_packed(packed));
+            assert_eq!(tid, Tid::from_packed(packed));
+        }
+    }
+}
+
+#[cfg(loom)]
+mod util {
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    pub(crate) struct TinyConfig;
+
+    impl crate::Config for TinyConfig {
+        const INITIAL_PAGE_SIZE: usize = 4;
+    }
+
+    pub(crate) fn run_model(name: &'static str, f: impl Fn() + Sync + Send + 'static) {
+        run_builder(name, loom::model::Builder::new(), f)
+    }
+
+    pub(crate) fn run_builder(
+        name: &'static str,
+        builder: loom::model::Builder,
+        f: impl Fn() + Sync + Send + 'static,
+    ) {
+        let iters = AtomicUsize::new(1);
+        builder.check(move || {
+            test_println!(
+                "\n------------ running test {}; iteration {} ------------\n",
+                name,
+                iters.fetch_add(1, Ordering::SeqCst)
+            );
+            f()
+        });
+    }
+}
+
+#[cfg(loom)]
+mod loom_pool;
+#[cfg(loom)]
+mod loom_slab;


### PR DESCRIPTION
this branch makes the following minor test tweaks:
- use `/usr/bin/env bash` in loom scripts
- fix issues with thread ID reuse making loom unhappy
- separate `loom` and non-loom tests into separate cfgs