### PR TITLE
Make loom a dev-dependency (and upgrade proptest)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ lazy_static = "1"
 
 [dev-dependencies]
 loom = { version = "0.3", features = ["checkpoint"] }
-proptest = "0.9.4"
+proptest = "0.10"
 criterion = "0.3"
 slab = "0.4.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,10 @@ harness = false
 lazy_static = "1"
 
 [dev-dependencies]
+loom = { version = "0.3", features = ["checkpoint"] }
 proptest = "0.9.4"
 criterion = "0.3"
 slab = "0.4.2"
 
 [target.'cfg(loom)'.dependencies]
-loom = { version = "0.3", features = ["checkpoint"] }
+loom = { version = "0.3", features = ["checkpoint"], optional = true }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,6 +1,6 @@
 pub(crate) use self::inner::*;
 
-#[cfg(loom)]
+#[cfg(all(loom, any(test, feature = "loom")))]
 mod inner {
     pub(crate) use loom::cell::UnsafeCell;
     pub(crate) use loom::lazy_static;
@@ -62,7 +62,7 @@ mod inner {
     }
 }
 
-#[cfg(not(loom))]
+#[cfg(not(all(loom, any(feature = "loom", test))))]
 mod inner {
     #![allow(dead_code)]
     pub(crate) use lazy_static::lazy_static;

--- a/src/tid.rs
+++ b/src/tid.rs
@@ -169,7 +169,7 @@ impl Registration {
 // panics. T_T
 // Just skip TID reuse and use loom's lazy_static macro to ensure we have a
 // clean initial TID on every iteration, instead.
-#[cfg(not(loom))]
+#[cfg(not(all(loom, any(feature = "loom", test))))]
 impl Drop for Registration {
     fn drop(&mut self) {
         if let Some(id) = self.0.get() {


### PR DESCRIPTION
I'm not sure this doesn't muck up the way you use loom, but it would be nice if loom was listed as a dev-dependency (as it is in tokio) so that its dependencies don't end up being in downstream Cargo.lock files.

(Upgraded proptest too since I happened to notice it and the upgrade seemed trivial anyway.)