### PR TITLE
chore: update test dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,10 @@ harness = false
 lazy_static = "1"
 
 [dev-dependencies]
-loom = { version = "0.4", features = ["checkpoint"] }
+loom = { version = "0.5", features = ["checkpoint"] }
 proptest = "1"
 criterion = "0.3"
 slab = "0.4.2"
 
 [target.'cfg(loom)'.dependencies]
-loom = { version = "0.4", features = ["checkpoint"], optional = true }
+loom = { version = "0.5", features = ["checkpoint"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ lazy_static = "1"
 
 [dev-dependencies]
 loom = { version = "0.4", features = ["checkpoint"] }
-proptest = "0.10"
+proptest = "1"
 criterion = "0.3"
 slab = "0.4.2"
 


### PR DESCRIPTION
This just updates the `loom` and `proptest` dependencies
to the latest releases. No API changes in these.