### PR TITLE
chore: prepare to release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Bug Fixes
 
 *   set up MSRV in CI (#61) ([dfcc9080](https://github.com/hawkw/sharded-slab/commit/dfcc9080a62d08e359f298a9ffb0f275928b83e4), closes [#60](https://github.com/hawkw/sharded-slab/issues/60))
+* **tests:**  duplicate `hint` mod defs with loom ([0ce3fd91](https://github.com/hawkw/sharded-slab/commit/0ce3fd91feac8b4edb4f1ece6aebfc4ba4e50026))
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="v0.1.3"></a>
+### v0.1.3 (2021-08-02)
+
+
+#### Bug Fixes
+
+*   set up MSRV in CI (#61) ([dfcc9080](https://github.com/hawkw/sharded-slab/commit/dfcc9080a62d08e359f298a9ffb0f275928b83e4), closes [#60](https://github.com/hawkw/sharded-slab/issues/60))
+
+
+
 <a name="0.1.2"></a>
 ### 0.1.2 (2021-08-01)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "sharded-slab"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
 edition = "2018"
-documentation = "https://docs.rs/sharded-slab/0.1.2/sharded_slab"
+documentation = "https://docs.rs/sharded-slab/0.1.3/sharded_slab"
 homepage = "https://github.com/hawkw/sharded-slab"
 repository = "https://github.com/hawkw/sharded-slab"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A lock-free concurrent slab.
 [crates-badge]: https://img.shields.io/crates/v/sharded-slab.svg
 [crates-url]: https://crates.io/crates/sharded-slab
 [docs-badge]: https://docs.rs/sharded-slab/badge.svg
-[docs-url]: https://docs.rs/sharded-slab/0.1.2/sharded_slab
+[docs-url]: https://docs.rs/sharded-slab/0.1.3/sharded_slab
 [ci-badge]: https://github.com/hawkw/sharded-slab/workflows/CI/badge.svg
 [ci-url]: https://github.com/hawkw/sharded-slab/actions?workflow=CI
 [license-badge]: https://img.shields.io/crates/l/sharded-slab
@@ -57,12 +57,12 @@ _data_ they store, but retaining any previously-allocated capacity. This
 means that a [`Pool`] may be used to reuse a set of existing heap
 allocations, reducing allocator load.
 
-[`Slab`]: https://docs.rs/sharded-slab/0.1.2/sharded_slab/struct.Slab.html
-[inserting]: https://docs.rs/sharded-slab/0.1.2/sharded_slab/struct.Slab.html#method.insert
-[taking]: https://docs.rs/sharded-slab/0.1.2/sharded_slab/struct.Slab.html#method.take
-[`Pool`]: https://docs.rs/sharded-slab/0.1.2/sharded_slab/struct.Pool.html
-[create]: https://docs.rs/sharded-slab/0.1.2/sharded_slab/struct.Pool.html#method.create
-[cleared]: https://docs.rs/sharded-slab/0.1.2/sharded_slab/trait.Clear.html
+[`Slab`]: https://docs.rs/sharded-slab/0.1.3/sharded_slab/struct.Slab.html
+[inserting]: https://docs.rs/sharded-slab/0.1.3/sharded_slab/struct.Slab.html#method.insert
+[taking]: https://docs.rs/sharded-slab/0.1.3/sharded_slab/struct.Slab.html#method.take
+[`Pool`]: https://docs.rs/sharded-slab/0.1.3/sharded_slab/struct.Pool.html
+[create]: https://docs.rs/sharded-slab/0.1.3/sharded_slab/struct.Pool.html#method.create
+[cleared]: https://docs.rs/sharded-slab/0.1.3/sharded_slab/trait.Clear.html
 [object pool]: https://en.wikipedia.org/wiki/Object_pool_pattern
 
 ### Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,7 +199,7 @@
 //! See [this page](implementation/index.html) for details on this crate's design
 //! and implementation.
 //!
-#![doc(html_root_url = "https://docs.rs/sharded-slab/0.1.2")]
+#![doc(html_root_url = "https://docs.rs/sharded-slab/0.1.3")]
 #![warn(missing_debug_implementations, missing_docs, missing_doc_code_examples)]
 
 #[macro_use]


### PR DESCRIPTION
### v0.1.3 (2021-08-02)
#### Bug Fixes

*   set up MSRV in CI (#61) ([dfcc9080](https://github.com/hawkw/sharded-slab/commit/dfcc9080a62d08e359f298a9ffb0f275928b83e4), closes [#60](https://github.com/hawkw/sharded-slab/issues/60))
* **tests:**  duplicate `hint` mod defs with loom ([0ce3fd91](https://github.com/hawkw/sharded-slab/commit/0ce3fd91feac8b4edb4f1ece6aebfc4ba4e50026))