### PR TITLE
feat: emit a nicer panic when thread count overflows `MAX_SHARDS`

### DIFF
--- a/src/shard.rs
+++ b/src/shard.rs
@@ -293,7 +293,7 @@ where
         test_println!("current: {:?}", tid);
         let idx = tid.as_usize();
         assert!(
-            idx >= self.shards.len(),
+            idx < self.shards.len(),
             "Thread count overflowed the configured max count. \
             Thread index = {}, max threads = {}.",
             idx,


### PR DESCRIPTION
Tackles https://github.com/hawkw/sharded-slab/issues/62#issuecomment-939336275. I don't know if there are other places that could panic, though, I just personally hit that line.