### PR TITLE
Swap out lazy_static for once_cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ name = "bench"
 harness = false
 
 [dependencies]
-lazy_static = "1"
+once_cell = "1.12"
 
 [dev-dependencies]
 loom = { version = "0.5", features = ["checkpoint"] }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -62,8 +62,6 @@ mod inner {
 
 #[cfg(not(all(loom, any(feature = "loom", test))))]
 mod inner {
-    #![allow(dead_code)]
-    pub(crate) use lazy_static::lazy_static;
     pub(crate) use std::{
         sync::{atomic, Mutex},
         thread::yield_now,
@@ -122,18 +120,6 @@ mod inner {
             #[inline(always)]
             pub fn get_ref(&self) -> &T {
                 &self.value
-            }
-
-            /// Get a mutable reference to the value
-            #[inline(always)]
-            pub fn get_mut(&mut self) -> &mut T {
-                &mut self.value
-            }
-
-            /// Stop tracking the value for leaks
-            #[inline(always)]
-            pub fn into_inner(self) -> T {
-                self.value
             }
         }
     }

--- a/src/tid.rs
+++ b/src/tid.rs
@@ -3,7 +3,7 @@ use crate::{
     page,
     sync::{
         atomic::{AtomicUsize, Ordering},
-        lazy_static, thread_local, Mutex,
+        thread_local, Mutex,
     },
     Pack,
 };
@@ -14,6 +14,7 @@ use std::{
     marker::PhantomData,
     sync::PoisonError,
 };
+use once_cell::sync::Lazy;
 
 /// Uniquely identifies a thread.
 pub(crate) struct Tid<C> {
@@ -27,15 +28,13 @@ struct Registration(Cell<Option<usize>>);
 
 struct Registry {
     next: AtomicUsize,
-    free: Mutex<VecDeque<usize>>,
+    free: Lazy<Mutex<VecDeque<usize>>>,
 }
 
-lazy_static! {
-    static ref REGISTRY: Registry = Registry {
-        next: AtomicUsize::new(0),
-        free: Mutex::new(VecDeque::new()),
-    };
-}
+static REGISTRY: Registry = Registry {
+    next: AtomicUsize::new(0),
+    free: Lazy::new(|| Mutex::new(VecDeque::new())),
+};
 
 thread_local! {
     static REGISTRATION: Registration = Registration::new();


### PR DESCRIPTION
Fixes #71. Another benefit is that accessing registry's next counter doesn't require an extra lazy check, only on the actual freelist.