### PR TITLE
fix(Slab): invalid generation in case of custom config

### DIFF
--- a/src/page/slot.rs
+++ b/src/page/slot.rs
@@ -134,7 +134,7 @@ where
             let new_refs = refs.incr()?;
             match self.lifecycle.compare_exchange(
                 lifecycle,
-                new_refs.pack(current_gen.pack(state.pack(0))),
+                new_refs.pack(lifecycle),
                 Ordering::AcqRel,
                 Ordering::Acquire,
             ) {
@@ -242,7 +242,7 @@ where
         let mut spin_exp = 0;
         let next_gen = gen.advance();
         loop {
-            let current_gen = Generation::from_packed(lifecycle);
+            let current_gen = LifecycleGen::from_packed(lifecycle).0;
             test_println!("-> release_with; lifecycle={:#x}; expected_gen={:?}; current_gen={:?}; next_gen={:?};",
                 lifecycle,
                 gen,
@@ -261,7 +261,7 @@ where
 
             match self.lifecycle.compare_exchange(
                 lifecycle,
-                next_gen.pack(lifecycle),
+                LifecycleGen(next_gen).pack(lifecycle),
                 Ordering::AcqRel,
                 Ordering::Acquire,
             ) {
@@ -499,8 +499,9 @@ impl<T, C: cfg::Config> Slot<T, C> {
             // Are we the last guard, and is the slot marked for removal?
             let dropping = refs.value == 1 && state == State::Marked;
             let new_lifecycle = if dropping {
-                // If so, we want to advance the state to "removing"
-                gen.pack(State::Removing as usize)
+                // If so, we want to advance the state to "removing".
+                // Also, reset the ref count to 0.
+                LifecycleGen(gen).pack(State::Removing as usize)
             } else {
                 // Otherwise, just subtract 1 from the ref count.
                 refs.decr().pack(lifecycle)
@@ -875,7 +876,8 @@ impl<T, C: cfg::Config> InitGuard<T, C> {
 
             debug_assert!(state == State::Marked || thread::panicking(), "state was not MARKED; someone else has removed the slot while we have exclusive access!\nactual={:?}", state);
             debug_assert!(refs.value == 0 || thread::panicking(), "ref count was not 0; someone else has referenced the slot while we have exclusive access!\nactual={:?}", refs);
-            let new_lifecycle = self.generation().pack(State::Removing as usize);
+
+            let new_lifecycle = LifecycleGen(self.generation()).pack(State::Removing as usize);
 
             match slot.lifecycle.compare_exchange(
                 curr_lifecycle,

--- a/src/tests/custom_config.rs
+++ b/src/tests/custom_config.rs
@@ -1,0 +1,66 @@
+//! Ensures that a custom config behaves as the default config, until limits are reached.
+//! Prevents regression after #80.
+
+#![cfg(not(loom))]
+
+use crate::{Config, Slab};
+
+struct CustomConfig;
+impl Config for CustomConfig {
+    const INITIAL_PAGE_SIZE: usize = 32;
+    const MAX_PAGES: usize = 15;
+    const MAX_THREADS: usize = 256;
+    const RESERVED_BITS: usize = 24;
+}
+
+// We should repeat actions several times to detect invalid lifecycle changes.
+const ITERS: u64 = 5;
+
+#[track_caller]
+fn slab_eq(mut lhs: Slab<u64, impl Config>, mut rhs: Slab<u64, impl Config>) {
+    let mut lhs_vec = lhs.unique_iter().collect::<Vec<_>>();
+    lhs_vec.sort_unstable();
+    let mut rhs_vec = rhs.unique_iter().collect::<Vec<_>>();
+    rhs_vec.sort_unstable();
+    assert_eq!(lhs_vec, rhs_vec);
+}
+
+/// Calls `insert(); remove()` multiple times to detect invalid releasing.
+/// Initially, it revealed bugs in the `Slot::release_with()` implementation.
+#[test]
+fn insert_remove() {
+    let default_slab = Slab::<u64, _>::new();
+    let custom_slab = Slab::<u64, _>::new_with_config::<CustomConfig>();
+
+    for i in 0..=ITERS {
+        let idx = default_slab.insert(i).unwrap();
+        assert!(default_slab.remove(idx));
+
+        let idx = custom_slab.insert(i).unwrap();
+        assert!(custom_slab.remove(idx));
+    }
+
+    slab_eq(custom_slab, default_slab);
+}
+
+/// Calls `get()` multiple times to detect invalid ref counting.
+/// Initially, it revealed bugs in the `Slot::get()` implementation.
+#[test]
+fn double_get() {
+    let default_slab = Slab::<u64, _>::new();
+    let custom_slab = Slab::<u64, _>::new_with_config::<CustomConfig>();
+
+    for i in 0..=ITERS {
+        let idx = default_slab.insert(i).unwrap();
+        assert!(default_slab.get(idx).is_some());
+        assert!(default_slab.get(idx).is_some());
+        assert!(default_slab.remove(idx));
+
+        let idx = custom_slab.insert(i).unwrap();
+        assert!(custom_slab.get(idx).is_some());
+        assert!(custom_slab.get(idx).is_some());
+        assert!(custom_slab.remove(idx));
+    }
+
+    slab_eq(custom_slab, default_slab);
+}

--- a/src/tests/loom_slab.rs
+++ b/src/tests/loom_slab.rs
@@ -381,7 +381,7 @@ fn remove_remote_during_insert() {
 #[test]
 fn unique_iter() {
     run_model("unique_iter", || {
-        let mut slab = std::sync::Arc::new(Slab::new());
+        let mut slab = Arc::new(Slab::new());
 
         let s = slab.clone();
         let t1 = thread::spawn(move || {
@@ -398,7 +398,7 @@ fn unique_iter() {
         t1.join().expect("thread 1 should not panic");
         t2.join().expect("thread 2 should not panic");
 
-        let slab = std::sync::Arc::get_mut(&mut slab).expect("other arcs should be dropped");
+        let slab = Arc::get_mut(&mut slab).expect("other arcs should be dropped");
         let items: Vec<_> = slab.unique_iter().map(|&i| i).collect();
         assert!(items.contains(&1), "items: {:?}", items);
         assert!(items.contains(&2), "items: {:?}", items);

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -65,6 +65,7 @@ pub(crate) mod util {
     }
 }
 
+mod custom_config;
 #[cfg(loom)]
 mod loom_pool;
 #[cfg(loom)]


### PR DESCRIPTION
Hi, I used the following config and found the incorrect calculations of the generation and reference counter. After debugging, I  discovered that sometimes `Generation::pack` is used instead of `LifecycleGen::pack`, which can be fixed by this PR.

My config:
```rust
struct SlabConfig;
impl sharded_slab::Config for SlabConfig {
    const INITIAL_PAGE_SIZE: usize = 32;
    const MAX_PAGES: usize = 15;
    const MAX_THREADS: usize = 256;
    const RESERVED_BITS: usize = 24;
}
```

The bug cannot be reproduced with the default config, because `Generation` and `LifecycleGen` have the same `Pack::SHIFT`.

It would be nice to remove `impl Pack for Generation` in favor of different `impl Pack for KeyGen` and `impl Pack for LifecycleGen`, but I decided not to do any extra refactoring, which you may not accept.

If the patch is ok for you, I can add a test to prevent regression in the future.