### PR TITLE
Update minimum supported lazy_static version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ name = "bench"
 harness = false
 
 [dependencies]
-lazy_static = "1"
+lazy_static = "1.1"
 
 [dev-dependencies]
 loom = { version = "0.5", features = ["checkpoint"] }


### PR DESCRIPTION
The current `Cargo.toml` on the main branch says that any lazy_static from 1.0.0 should be supported, but that is not actually the case. Building the crate with 1.0.0 and 1.0.1 does not compile at all, whereas 1.0.2 compiles with warnings on any Rust since 1.38. Starting from lazy_static 1.1 the crate actually compiles without warnings.