### PR TITLE
test: add a test reproducing #83

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ loom = { version = "0.5", features = ["checkpoint"] }
 proptest = "1"
 criterion = "0.3"
 slab = "0.4.2"
+memory-stats = "1"
 
 [target.'cfg(loom)'.dependencies]
 loom = { version = "0.5", features = ["checkpoint"], optional = true }

--- a/tests/reserved_bits_leak.rs
+++ b/tests/reserved_bits_leak.rs
@@ -1,0 +1,26 @@
+// Reproduces https://github.com/hawkw/sharded-slab/issues/83
+use memory_stats::memory_stats;
+use sharded_slab::Config;
+use sharded_slab::Slab;
+
+struct CustomConfig;
+impl Config for CustomConfig {
+    const RESERVED_BITS: usize = 1; // This is the cause.
+}
+
+#[test]
+fn reserved_bits_doesnt_leak() {
+    let slab = Slab::new_with_config::<CustomConfig>();
+    for n in 0..1000 {
+        let mem_before = memory_stats().unwrap();
+        let key = slab.insert(0).unwrap();
+        slab.remove(key);
+        let usage = memory_stats().unwrap();
+        eprintln!(
+            "n: {n:<4}\tkey: {key:#08x} rss: {:>16} vs:{:>16}",
+            usage.physical_mem, usage.virtual_mem
+        );
+
+        assert_eq!(mem_before.virtual_mem, usage.virtual_mem);
+    }
+}


### PR DESCRIPTION
This commit adds an integration test reproducing #83.

I ran this test before and after the changes from PR #80, and I can
confirm that the test fails without the changes from #80, but passes
after #80. So, this means that #80 fixed the issue described in #83!

Fixes #80