### PR TITLE
chore(CI): use musl for 32-bit builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
           - x86_64-unknown-linux-gnu
         include:
           - rust: stable
-            target: i686-unknown-linux-gnu
+            target: i686-unknown-linux-musl
     name: cargo +${{ matrix.rust }} build --target ${{ matrix.target }}
     steps:
       - uses: actions/checkout@master

--- a/src/tests/custom_config.rs
+++ b/src/tests/custom_config.rs
@@ -16,7 +16,7 @@ impl Config for CustomConfig {
 }
 
 #[cfg(not(target_pointer_width = "64"))]
-impl Config for CustomConfig32 {
+impl Config for CustomConfig {
     const INITIAL_PAGE_SIZE: usize = 16;
     const MAX_PAGES: usize = 7;
     const MAX_THREADS: usize = 128;

--- a/src/tests/custom_config.rs
+++ b/src/tests/custom_config.rs
@@ -18,7 +18,7 @@ impl Config for CustomConfig {
 #[cfg(not(target_pointer_width = "64"))]
 impl Config for CustomConfig {
     const INITIAL_PAGE_SIZE: usize = 16;
-    const MAX_PAGES: usize = 7;
+    const MAX_PAGES: usize = 6;
     const MAX_THREADS: usize = 128;
     const RESERVED_BITS: usize = 12;
 }


### PR DESCRIPTION
This commit changes the 32-bit CI builds to use a musl toolchain rather than glibc, so that CI can stop complaining that there's no 32-bit glibc.