### PR TITLE
Fix bugs in get() and co + property based tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,21 +2,25 @@ name: CI
 
 on: [pull_request]
 
+env:
+  RUSTFLAGS: -Dwarnings
+  RUST_BACKTRACE: 1
+  MSRV: 1.42.0
+
 jobs:
   build:
+    name: Build for ${{ matrix.target }} (${{ matrix.rust }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
         rust:
           - stable
           - nightly
-          - 1.42.0
         target:
           - x86_64-unknown-linux-gnu
         include:
           - rust: stable
             target: i686-unknown-linux-musl
-    name: cargo +${{ matrix.rust }} build --target ${{ matrix.target }}
     steps:
       - uses: actions/checkout@master
       - name: Install toolchain
@@ -32,13 +36,30 @@ jobs:
           command: build
           args: --all-targets --target ${{ matrix.target }}
 
+  msrv:
+    name: Build (MSRV)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.MSRV }}
+          override: true
+      - name: cargo +${{ env.MSRV }} build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+        env:
+          RUSTFLAGS: "" # remove -Dwarnings
+
   test:
-    name: Tests
+    name: Tests (nightly)
     runs-on: ubuntu-latest
     needs: build
     steps:
       - uses: actions/checkout@master
-
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -49,13 +70,11 @@ jobs:
         run: cargo test
 
   test-loom:
-    name: Loom tests
+    name: Loom tests (nightly)
     runs-on: ubuntu-latest
     needs: build
-
     steps:
       - uses: actions/checkout@master
-
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -65,10 +84,10 @@ jobs:
       - name: Run Loom tests
         run: ./bin/loom.sh
 
-  clippy_check:
+  clippy:
+    name: Clippy (stable)
     runs-on: ubuntu-latest
     needs: build
-
     steps:
       - uses: actions/checkout@v2
       - name: Install toolchain
@@ -78,17 +97,16 @@ jobs:
           toolchain: stable
           components: clippy
           override: true
-      - name: Run clippy
+      - name: cargo clippy --all-targets --all-features
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
+          args: --all-targets --all-features
 
   rustfmt:
-    name: rustfmt
+    name: Rustfmt (stable)
     runs-on: ubuntu-latest
     needs: build
-
     steps:
       - uses: actions/checkout@v2
       - name: Install toolchain

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ proptest = "1"
 criterion = "0.3"
 slab = "0.4.2"
 memory-stats = "1"
-indexmap = "2"
+indexmap = "1" # newer versions lead to "candidate versions found which didn't match" on 1.42.0
 
 [target.'cfg(loom)'.dependencies]
 loom = { version = "0.5", features = ["checkpoint"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ proptest = "1"
 criterion = "0.3"
 slab = "0.4.2"
 memory-stats = "1"
+indexmap = "2"
 
 [target.'cfg(loom)'.dependencies]
 loom = { version = "0.5", features = ["checkpoint"], optional = true }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -26,7 +26,7 @@ impl<T: Send + Sync + 'static> MultithreadedBench<T> {
         let end = self.end.clone();
         let slab = self.slab.clone();
         thread::spawn(move || {
-            f(&*start, &*slab);
+            f(&start, &*slab);
             end.wait();
         });
         self

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,17 +1,19 @@
-use crate::{page, shard};
-use std::slice;
+use std::{iter::FusedIterator, slice};
 
-/// An exclusive iterator over the items in a [`Slab`](crate::Slab).
+use crate::{cfg, page, shard};
+
+/// An exclusive fused iterator over the items in a [`Slab`](crate::Slab).
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[derive(Debug)]
-pub struct UniqueIter<'a, T, C: crate::cfg::Config> {
+pub struct UniqueIter<'a, T, C: cfg::Config> {
     pub(super) shards: shard::IterMut<'a, Option<T>, C>,
     pub(super) pages: slice::Iter<'a, page::Shared<Option<T>, C>>,
     pub(super) slots: Option<page::Iter<'a, T, C>>,
 }
 
-impl<'a, T, C: crate::cfg::Config> Iterator for UniqueIter<'a, T, C> {
+impl<'a, T, C: cfg::Config> Iterator for UniqueIter<'a, T, C> {
     type Item = &'a T;
+
     fn next(&mut self) -> Option<Self::Item> {
         test_println!("UniqueIter::next");
         loop {
@@ -39,3 +41,5 @@ impl<'a, T, C: crate::cfg::Config> Iterator for UniqueIter<'a, T, C> {
         }
     }
 }
+
+impl<T, C: cfg::Config> FusedIterator for UniqueIter<'_, T, C> {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -744,13 +744,20 @@ impl<T, C: cfg::Config> Slab<T, C> {
     /// iteration is in progress.
     pub fn unique_iter(&mut self) -> iter::UniqueIter<'_, T, C> {
         let mut shards = self.shards.iter_mut();
-        let shard = shards.next().expect("must be at least 1 shard");
-        let mut pages = shard.iter();
-        let slots = pages.next().and_then(page::Shared::iter);
+
+        let (pages, slots) = match shards.next() {
+            Some(shard) => {
+                let mut pages = shard.iter();
+                let slots = pages.next().and_then(page::Shared::iter);
+                (pages, slots)
+            }
+            None => ([].iter(), None),
+        };
+
         iter::UniqueIter {
             shards,
-            slots,
             pages,
+            slots,
         }
     }
 }

--- a/src/page/mod.rs
+++ b/src/page/mod.rs
@@ -247,7 +247,7 @@ where
     }
 
     pub(crate) fn iter(&self) -> Option<Iter<'a, T, C>> {
-        let slab = self.slab.with(|slab| unsafe { (&*slab).as_ref() });
+        let slab = self.slab.with(|slab| unsafe { (*slab).as_ref() });
         slab.map(|slab| {
             slab.iter()
                 .filter_map(Shared::make_ref as fn(&'a Slot<Option<T>, C>) -> Option<&'a T>)
@@ -402,7 +402,7 @@ impl<C: cfg::Config> Ord for Addr<C> {
 
 impl<C: cfg::Config> Clone for Addr<C> {
     fn clone(&self) -> Self {
-        Self::from_usize(self.addr)
+        *self
     }
 }
 

--- a/src/page/slot.rs
+++ b/src/page/slot.rs
@@ -584,7 +584,7 @@ impl<C: cfg::Config> Ord for Generation<C> {
 
 impl<C: cfg::Config> Clone for Generation<C> {
     fn clone(&self) -> Self {
-        Self::new(self.value)
+        *self
     }
 }
 
@@ -748,7 +748,7 @@ impl<C: cfg::Config> Ord for RefCount<C> {
 
 impl<C: cfg::Config> Clone for RefCount<C> {
     fn clone(&self) -> Self {
-        Self::from_usize(self.value)
+        *self
     }
 }
 

--- a/src/shard.rs
+++ b/src/shard.rs
@@ -77,7 +77,7 @@ where
         let (addr, page_index) = page::indices::<C>(idx);
 
         test_println!("-> {:?}", addr);
-        if page_index > self.shared.len() {
+        if page_index >= self.shared.len() {
             return None;
         }
 
@@ -132,7 +132,7 @@ where
         debug_assert_eq_in_drop!(Tid::<C>::from_packed(idx).as_usize(), self.tid);
         let (addr, page_index) = page::indices::<C>(idx);
 
-        if page_index > self.shared.len() {
+        if page_index >= self.shared.len() {
             return false;
         }
 
@@ -143,7 +143,7 @@ where
         debug_assert_eq_in_drop!(Tid::<C>::from_packed(idx).as_usize(), self.tid);
         let (addr, page_index) = page::indices::<C>(idx);
 
-        if page_index > self.shared.len() {
+        if page_index >= self.shared.len() {
             return false;
         }
 
@@ -183,7 +183,7 @@ where
         debug_assert_eq_in_drop!(Tid::<C>::from_packed(idx).as_usize(), self.tid);
         let (addr, page_index) = page::indices::<C>(idx);
 
-        if page_index > self.shared.len() {
+        if page_index >= self.shared.len() {
             return false;
         }
 
@@ -194,7 +194,7 @@ where
         debug_assert_eq_in_drop!(Tid::<C>::from_packed(idx).as_usize(), self.tid);
         let (addr, page_index) = page::indices::<C>(idx);
 
-        if page_index > self.shared.len() {
+        if page_index >= self.shared.len() {
             return false;
         }
 
@@ -221,7 +221,7 @@ where
         debug_assert_eq_in_drop!(Tid::<C>::from_packed(idx).as_usize(), self.tid);
         let (addr, page_index) = page::indices::<C>(idx);
 
-        if page_index > self.shared.len() {
+        if page_index >= self.shared.len() {
             return false;
         }
 
@@ -232,7 +232,7 @@ where
         debug_assert_eq_in_drop!(Tid::<C>::from_packed(idx).as_usize(), self.tid);
         let (addr, page_index) = page::indices::<C>(idx);
 
-        if page_index > self.shared.len() {
+        if page_index >= self.shared.len() {
             return false;
         }
 

--- a/src/tests/custom_config.rs
+++ b/src/tests/custom_config.rs
@@ -1,8 +1,6 @@
 //! Ensures that a custom config behaves as the default config, until limits are reached.
 //! Prevents regression after #80.
 
-#![cfg(not(loom))]
-
 use crate::{cfg::CfgPrivate, Config, Slab};
 
 struct CustomConfig;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -65,8 +65,11 @@ pub(crate) mod util {
     }
 }
 
+#[cfg(not(loom))]
 mod custom_config;
 #[cfg(loom)]
 mod loom_pool;
 #[cfg(loom)]
 mod loom_slab;
+#[cfg(not(loom))]
+mod properties;

--- a/src/tests/properties.rs
+++ b/src/tests/properties.rs
@@ -1,0 +1,244 @@
+//! This module contains property-based tests against the public API:
+//! * API never panics.
+//! * Active entries cannot be overridden until removed.
+//! * The slab doesn't produce overlapping keys.
+//! * The slab doesn't leave "lost" keys.
+//! * `get()`, `get_owned`, and `contains()` are consistent.
+//! * `RESERVED_BITS` are actually not used.
+//!
+//! The test is supposed to be deterministic, so it doesn't spawn real threads
+//! and uses `tid::with()` to override the TID for the current thread.
+
+use std::{ops::Range, sync::Arc};
+
+use indexmap::IndexMap;
+use proptest::prelude::*;
+
+use crate::{tid, Config, DefaultConfig, Slab};
+
+const THREADS: Range<usize> = 1..4;
+const ACTIONS: Range<usize> = 1..1000;
+
+#[derive(Debug, Clone)]
+struct Action {
+    tid: usize,
+    kind: ActionKind,
+}
+
+#[derive(Debug, Clone)]
+enum ActionKind {
+    Insert,
+    VacantEntry,
+    RemoveRandom(usize),   // key
+    RemoveExistent(usize), // seed
+    TakeRandom(usize),     // key
+    TakeExistent(usize),   // seed
+    GetRandom(usize),      // key
+    GetExistent(usize),    // seed
+}
+
+prop_compose! {
+    fn action_strategy()(tid in THREADS, kind in action_kind_strategy()) -> Action {
+        Action { tid, kind }
+    }
+}
+
+fn action_kind_strategy() -> impl Strategy<Value = ActionKind> {
+    prop_oneof![
+        1 => Just(ActionKind::Insert),
+        1 => Just(ActionKind::VacantEntry),
+        1 => prop::num::usize::ANY.prop_map(ActionKind::RemoveRandom),
+        1 => prop::num::usize::ANY.prop_map(ActionKind::RemoveExistent),
+        1 => prop::num::usize::ANY.prop_map(ActionKind::TakeRandom),
+        1 => prop::num::usize::ANY.prop_map(ActionKind::TakeExistent),
+        // Produce `GetRandom` and `GetExistent` more often.
+        5 => prop::num::usize::ANY.prop_map(ActionKind::GetRandom),
+        5 => prop::num::usize::ANY.prop_map(ActionKind::GetExistent),
+    ]
+}
+
+/// Stores active entries (added and not yet removed).
+#[derive(Default)]
+struct Active {
+    // Use `IndexMap` to preserve determinism.
+    map: IndexMap<usize, u32>,
+    prev_value: u32,
+}
+
+impl Active {
+    fn next_value(&mut self) -> u32 {
+        self.prev_value += 1;
+        self.prev_value
+    }
+
+    fn get(&self, key: usize) -> Option<u32> {
+        self.map.get(&key).copied()
+    }
+
+    fn get_any(&self, seed: usize) -> Option<(usize, u32)> {
+        if self.map.is_empty() {
+            return None;
+        }
+
+        let index = seed % self.map.len();
+        self.map.get_index(index).map(|(k, v)| (*k, *v))
+    }
+
+    fn insert(&mut self, key: usize, value: u32) {
+        assert_eq!(
+            self.map.insert(key, value),
+            None,
+            "keys of active entries must be unique"
+        );
+    }
+
+    fn remove(&mut self, key: usize) -> Option<u32> {
+        self.map.swap_remove(&key)
+    }
+
+    fn remove_any(&mut self, seed: usize) -> Option<(usize, u32)> {
+        if self.map.is_empty() {
+            return None;
+        }
+
+        let index = seed % self.map.len();
+        self.map.swap_remove_index(index)
+    }
+
+    fn drain(&mut self) -> impl Iterator<Item = (usize, u32)> + '_ {
+        self.map.drain(..)
+    }
+}
+
+fn used_bits<C: Config>(key: usize) -> usize {
+    assert_eq!(
+        C::RESERVED_BITS + Slab::<u32, C>::USED_BITS,
+        std::mem::size_of::<usize>() * 8
+    );
+    key & ((!0) >> C::RESERVED_BITS)
+}
+
+fn apply_action<C: Config>(
+    slab: &Arc<Slab<u32, C>>,
+    active: &mut Active,
+    action: ActionKind,
+) -> Result<(), TestCaseError> {
+    match action {
+        ActionKind::Insert => {
+            let value = active.next_value();
+            let key = slab.insert(value).expect("unexpectedly exhausted slab");
+            prop_assert_eq!(used_bits::<C>(key), key);
+            active.insert(key, value);
+        }
+        ActionKind::VacantEntry => {
+            let value = active.next_value();
+            let entry = slab.vacant_entry().expect("unexpectedly exhausted slab");
+            let key = entry.key();
+            prop_assert_eq!(used_bits::<C>(key), key);
+            entry.insert(value);
+            active.insert(key, value);
+        }
+        ActionKind::RemoveRandom(key) => {
+            let used_key = used_bits::<C>(key);
+            prop_assert_eq!(slab.get(key).map(|e| *e), slab.get(used_key).map(|e| *e));
+            prop_assert_eq!(slab.remove(key), active.remove(used_key).is_some());
+        }
+        ActionKind::RemoveExistent(seed) => {
+            if let Some((key, _value)) = active.remove_any(seed) {
+                prop_assert!(slab.contains(key));
+                prop_assert!(slab.remove(key));
+            }
+        }
+        ActionKind::TakeRandom(key) => {
+            let used_key = used_bits::<C>(key);
+            prop_assert_eq!(slab.get(key).map(|e| *e), slab.get(used_key).map(|e| *e));
+            prop_assert_eq!(slab.take(key), active.remove(used_key));
+        }
+        ActionKind::TakeExistent(seed) => {
+            if let Some((key, value)) = active.remove_any(seed) {
+                prop_assert!(slab.contains(key));
+                prop_assert_eq!(slab.take(key), Some(value));
+            }
+        }
+        ActionKind::GetRandom(key) => {
+            let used_key = used_bits::<C>(key);
+            prop_assert_eq!(slab.get(key).map(|e| *e), slab.get(used_key).map(|e| *e));
+            prop_assert_eq!(slab.get(key).map(|e| *e), active.get(used_key));
+            prop_assert_eq!(
+                slab.clone().get_owned(key).map(|e| *e),
+                active.get(used_key)
+            );
+        }
+        ActionKind::GetExistent(seed) => {
+            if let Some((key, value)) = active.get_any(seed) {
+                prop_assert!(slab.contains(key));
+                prop_assert_eq!(slab.get(key).map(|e| *e), Some(value));
+                prop_assert_eq!(slab.clone().get_owned(key).map(|e| *e), Some(value));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn run<C: Config>(actions: Vec<Action>) -> Result<(), TestCaseError> {
+    let mut slab = Arc::new(Slab::new_with_config::<C>());
+    let mut active = Active::default();
+
+    // Apply all actions.
+    for action in actions {
+        // Override the TID for the current thread instead of using multiple real threads
+        // to preserve determinism. We're not checking concurrency issues here, they should be
+        // covered by loom tests anyway. Thus, it's fine to run all actions consequently.
+        tid::with(action.tid, || {
+            apply_action::<C>(&slab, &mut active, action.kind)
+        })?;
+    }
+
+    // Ensure the slab contains all remaining entries.
+    let mut expected_values = Vec::new();
+    for (key, value) in active.drain() {
+        prop_assert!(slab.contains(key));
+        prop_assert_eq!(slab.get(key).map(|e| *e), Some(value));
+        prop_assert_eq!(slab.clone().get_owned(key).map(|e| *e), Some(value));
+        expected_values.push(value);
+    }
+    expected_values.sort();
+
+    // Ensure `unique_iter()` returns all remaining entries.
+    let slab = Arc::get_mut(&mut slab).unwrap();
+    let mut actual_values = slab.unique_iter().copied().collect::<Vec<_>>();
+    actual_values.sort();
+    prop_assert_eq!(actual_values, expected_values);
+
+    Ok(())
+}
+
+proptest! {
+    #[test]
+    fn default_config(actions in prop::collection::vec(action_strategy(), ACTIONS)) {
+        run::<DefaultConfig>(actions)?;
+    }
+
+    #[test]
+    fn custom_config(actions in prop::collection::vec(action_strategy(), ACTIONS)) {
+        run::<CustomConfig>(actions)?;
+    }
+}
+
+struct CustomConfig;
+
+#[cfg(target_pointer_width = "64")]
+impl Config for CustomConfig {
+    const INITIAL_PAGE_SIZE: usize = 32;
+    const MAX_PAGES: usize = 15;
+    const MAX_THREADS: usize = 256;
+    const RESERVED_BITS: usize = 24;
+}
+#[cfg(target_pointer_width = "32")]
+impl Config for CustomConfig {
+    const INITIAL_PAGE_SIZE: usize = 16;
+    const MAX_PAGES: usize = 6;
+    const MAX_THREADS: usize = 128;
+    const RESERVED_BITS: usize = 12;
+}

--- a/src/tid.rs
+++ b/src/tid.rs
@@ -192,3 +192,18 @@ impl Drop for Registration {
         }
     }
 }
+
+#[cfg(test)]
+pub(crate) fn with<R>(tid: usize, f: impl FnOnce() -> R) -> R {
+    struct Guard(Option<usize>);
+
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            REGISTRATION.with(|r| r.0.set(self.0.take()));
+        }
+    }
+
+    let prev = REGISTRATION.with(|r| r.0.replace(Some(tid)));
+    let _guard = Guard(prev);
+    f()
+}

--- a/src/tid.rs
+++ b/src/tid.rs
@@ -123,7 +123,7 @@ impl<C> Eq for Tid<C> {}
 
 impl<C: cfg::Config> Clone for Tid<C> {
     fn clone(&self) -> Self {
-        Self::new(self.id)
+        *self
     }
 }
 


### PR DESCRIPTION
I've written some ~~fuzzing~~ property based tests for public API. Fortunately (or not), it's found only simple bugs with boundary checks (caught in staging, the reason why I've decided to check the slab in such a way).

* Add fuzzing tests for public API
* Fix #73 (`unique_iter`)
* Fix panics in `get()` for some keys
* Satisfy [clippy](https://rust-lang.github.io/rust-clippy/master/index.html#incorrect_clone_impl_on_copy_type)

P.S. "fuzzing" is not an entirely valid name here. Initially, It checked only the absence of panics, so naming was more appropriate. Then, more properties were added. Would you happen to have any ideas on how to call it now?