### PR TITLE
more CI embetterments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,34 +12,29 @@ env:
 
 jobs:
   build:
-    name: Build ((${{ matrix.rust }}, ${{ matrix.target }})
+    name: Build (stable, ${{ matrix.target }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust:
-          - stable
-          - nightly
         target:
           - x86_64-unknown-linux-gnu
-        include:
-          - rust: stable
-            target: i686-unknown-linux-musl
+          - i686-unknown-linux-musl
     steps:
       - uses: actions/checkout@master
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: ${{ matrix.rust }}
+          toolchain: stable
           target: ${{ matrix.target }}
           override: true
-      - name: cargo +${{ matrix.rust }} build --target ${{ matrix.target }}
+      - name: cargo build --target ${{ matrix.target }}
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: --all-targets --target ${{ matrix.target }}
 
-  msrv:
+  build-msrv:
     name: Build (MSRV)
     runs-on: ubuntu-latest
     steps:
@@ -57,8 +52,27 @@ jobs:
         env:
           RUSTFLAGS: "" # remove -Dwarnings
 
+  build-nightly:
+    name: Build (nightly)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - name: cargo +nightly build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+        env:
+          RUSTFLAGS: "" # remove -Dwarnings
+
   test:
     name: Tests (stable)
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -73,6 +87,7 @@ jobs:
 
   test-loom:
     name: Loom tests (stable)
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -125,7 +140,11 @@ jobs:
     name: "all systems go!"
     needs:
       - build
-      - msrv
+      - build-msrv
+      # Note: we explicitly *don't* require the `build-nightly` job to pass,
+      # since the nightly Rust compiler is unstable. We don't want nightly
+      # regressions to break our build --- this CI job is intended for
+      # informational reasons rather than as a gatekeeper for merging PRs.
       - test
       - test-loom
       - clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [pull_request]
+on:
+  push:
+    branches: ["main"]
+  pull_request:
 
 env:
   RUSTFLAGS: -Dwarnings
@@ -57,7 +60,6 @@ jobs:
   test:
     name: Tests (stable)
     runs-on: ubuntu-latest
-    needs: build
     steps:
       - uses: actions/checkout@master
       - name: Install toolchain
@@ -72,7 +74,6 @@ jobs:
   test-loom:
     name: Loom tests (stable)
     runs-on: ubuntu-latest
-    needs: build
     steps:
       - uses: actions/checkout@master
       - name: Install toolchain
@@ -87,7 +88,6 @@ jobs:
   clippy:
     name: Clippy (stable)
     runs-on: ubuntu-latest
-    needs: build
     steps:
       - uses: actions/checkout@v2
       - name: Install toolchain
@@ -106,7 +106,6 @@ jobs:
   rustfmt:
     name: Rustfmt (stable)
     runs-on: ubuntu-latest
-    needs: build
     steps:
       - uses: actions/checkout@v2
       - name: Install toolchain
@@ -121,3 +120,16 @@ jobs:
         with:
           command: fmt
           args: -- --check
+
+  all-systems-go:
+    name: "all systems go!"
+    needs:
+      - build
+      - msrv
+      - test
+      - test-loom
+      - clippy
+      - rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   build:
-    name: Build for ${{ matrix.target }} (${{ matrix.rust }})
+    name: Build ((${{ matrix.rust }}, ${{ matrix.target }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -55,7 +55,7 @@ jobs:
           RUSTFLAGS: "" # remove -Dwarnings
 
   test:
-    name: Tests (nightly)
+    name: Tests (stable)
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -64,13 +64,13 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           override: true
       - name: Run tests
         run: cargo test
 
   test-loom:
-    name: Loom tests (nightly)
+    name: Loom tests (stable)
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -79,7 +79,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           override: true
       - name: Run Loom tests
         run: ./bin/loom.sh


### PR DESCRIPTION
This way, we can use that as the required check for merging PRs, so we
don't have to depend on a bunch of stuff in the GitHub branch protection
settings. This means that the required checks are defined in the CI
config file, rather than in the UI, and if we change job names
or add new checks, we can add them to the requirements in `ci.yml`
instead of the repo settings.