### PR TITLE
Remove lazy_static, requires raising MSRV to 1.68

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 env:
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
-  MSRV: 1.42.0
+  MSRV: 1.68.0
 
 jobs:
   build:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ documentation = "https://docs.rs/sharded-slab/"
 homepage = "https://github.com/hawkw/sharded-slab"
 repository = "https://github.com/hawkw/sharded-slab"
 readme = "README.md"
-rust-version = "1.42.0"
+rust-version = "1.68.0"
 license = "MIT"
 keywords = ["slab", "allocator", "lock-free", "atomic"]
 categories = ["memory-management", "data-structures", "concurrency"]
@@ -31,9 +31,6 @@ maintenance = { status = "experimental" }
 [[bench]]
 name = "bench"
 harness = false
-
-[dependencies]
-lazy_static = "1"
 
 [dev-dependencies]
 proptest = "1"

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,13 +1,7 @@
 macro_rules! test_println {
     ($($arg:tt)*) => {
         if cfg!(test) && cfg!(slab_print) {
-            if std::thread::panicking() {
-                // getting the thread ID while panicking doesn't seem to play super nicely with loom's
-                // mock lazy_static...
-                println!("[PANIC {:>17}:{:<3}] {}", file!(), line!(), format_args!($($arg)*))
-            } else {
-                println!("[{:?} {:>17}:{:<3}] {}", crate::Tid::<crate::DefaultConfig>::current(), file!(), line!(), format_args!($($arg)*))
-            }
+            println!("[{:?} {:>17}:{:<3}] {}", crate::Tid::<crate::DefaultConfig>::current(), file!(), line!(), format_args!($($arg)*))
         }
     }
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -6,9 +6,7 @@ mod inner {
         pub use loom::sync::atomic::*;
         pub use std::sync::atomic::Ordering;
     }
-    pub(crate) use loom::{
-        cell::UnsafeCell, hint, lazy_static, sync::Mutex, thread::yield_now, thread_local,
-    };
+    pub(crate) use loom::{cell::UnsafeCell, hint, sync::Mutex, thread::yield_now, thread_local};
 
     pub(crate) mod alloc {
         #![allow(dead_code)]
@@ -63,7 +61,6 @@ mod inner {
 #[cfg(not(all(loom, any(feature = "loom", test))))]
 mod inner {
     #![allow(dead_code)]
-    pub(crate) use lazy_static::lazy_static;
     pub(crate) use std::{
         sync::{atomic, Mutex},
         thread::yield_now,


### PR DESCRIPTION
#72 suggested lazy_static could be removed in 1.68 as `VecDeque::new` became a const fn. This PR materializes that suggestion