### PR TITLE
Switch to OnceLock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ name = "bench"
 harness = false
 
 [dependencies]
-lazy_static = "1"
+lazy_static = "1.5.0"
 
 [dev-dependencies]
 proptest = "1"


### PR DESCRIPTION
After issues report in lazy static target and rust releases in many crate switched to OnceLock to be steady mode with rust .