### PR TITLE
chore: Fix "unexpected `cfg` condition name"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,3 +51,6 @@ loom = { version = "0.5", features = ["checkpoint"] }
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)', 'cfg(slab_print)'] }


### PR DESCRIPTION
On current main(`ee45b4cfa79408fc46893a67f2d3005f79e4e04c`) with Rust 1.83 (`rustc 1.83.0 (90b35a623 2024-11-26)`, `cargo 1.83.0 (5ffbef321 2024-10-29)`), running `cargo check` gives many warnings, almost all of which are duplicates of these two:

```
warning: unexpected `cfg` condition name: `slab_print`
   --> src/macros.rs:3:31
    |
3   |         if cfg!(test) && cfg!(slab_print) {
    |                               ^^^^^^^^^^
    |
   ::: src/lib.rs:967:9
    |
967 |         test_println!("drop OwnedEntry: try clearing data");
    |         --------------------------------------------------- in this macro invocation
    |
    = help: consider using a Cargo feature instead
    = help: or consider adding in `Cargo.toml` the `check-cfg` lint config for the lint:
             [lints.rust]
             unexpected_cfgs = { level = "warn", check-cfg = ['cfg(slab_print)'] }
    = help: or consider adding `println!("cargo::rustc-check-cfg=cfg(slab_print)");` to the top of the `build.rs`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
    = note: this warning originates in the macro `test_println` (in Nightly builds, run with -Z macro-backtrace for more info)
```

```
warning: unexpected `cfg` condition name: `loom`
  --> src/macros.rs:15:17
   |
15 | #[cfg(all(test, loom))]
   |                 ^^^^ help: found config with similar value: `feature = "loom"`
   |
   = help: expected names are: `clippy`, `debug_assertions`, `doc`, `docsrs`, `doctest`, `feature`, `fmt_debug`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `rustfmt`, `sanitize`, `sanitizer_cfi_generalize_pointers`, `sanitizer_cfi_normalize_integers`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `ub_checks`, `unix`, and `windows`
   = help: consider using a Cargo feature instead
   = help: or consider adding in `Cargo.toml` the `check-cfg` lint config for the lint:
            [lints.rust]
            unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }
   = help: or consider adding `println!("cargo::rustc-check-cfg=cfg(loom)");` to the top of the `build.rs`
   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
   = note: `#[warn(unexpected_cfgs)]` on by default
```

This PR uses the suggested `Cargo.toml` changes to fix it.
