### PR TITLE
chore: Fix "unused manifest key: package.ignore"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["memory-management", "data-structures", "concurrency"]
 description = """
 A lock-free concurrent slab.
 """
-ignore = [
+exclude = [
     "flake.nix",
     "flake.lock",
     ".envrc",


### PR DESCRIPTION
On current main (`ee45b4cfa79408fc46893a67f2d3005f79e4e04c`) with Rust 1.83 (`rustc 1.83.0 (90b35a623 2024-11-26)`, `cargo 1.83.0 (5ffbef321 2024-10-29)`), running `cargo check` gives this warning:

```
warning: unused manifest key: package.ignore
```

Note: this warning may be buried under other warnings that could be fixed by #102.

hawkw committed the `ignore = ["flake.nix", "flake.lock", ...]` key in 90bf2e92db1546eb7c1819da38fc741117b1a4a8 in 2023. I cannot find any reference online to there being an `ignore` key in Cargo manifests, and fram context I am guessing that this was intended to be `exclude`, which is documentd [here](https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields).

This PR fixes the warning by changing the key to `exclude`.