### PR TITLE
chore: Clippy autofix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -782,7 +782,7 @@ unsafe impl<T: Sync, C: cfg::Config> Sync for Slab<T, C> {}
 
 // === impl Entry ===
 
-impl<'a, T, C: cfg::Config> Entry<'a, T, C> {
+impl<T, C: cfg::Config> Entry<'_, T, C> {
     /// Returns the key used to access the guard.
     pub fn key(&self) -> usize {
         self.key
@@ -799,7 +799,7 @@ impl<'a, T, C: cfg::Config> Entry<'a, T, C> {
     }
 }
 
-impl<'a, T, C: cfg::Config> std::ops::Deref for Entry<'a, T, C> {
+impl<T, C: cfg::Config> std::ops::Deref for Entry<'_, T, C> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -807,7 +807,7 @@ impl<'a, T, C: cfg::Config> std::ops::Deref for Entry<'a, T, C> {
     }
 }
 
-impl<'a, T, C: cfg::Config> Drop for Entry<'a, T, C> {
+impl<T, C: cfg::Config> Drop for Entry<'_, T, C> {
     fn drop(&mut self) {
         let should_remove = unsafe {
             // Safety: calling `slot::Guard::release` is unsafe, since the
@@ -824,7 +824,7 @@ impl<'a, T, C: cfg::Config> Drop for Entry<'a, T, C> {
     }
 }
 
-impl<'a, T, C> fmt::Debug for Entry<'a, T, C>
+impl<T, C> fmt::Debug for Entry<'_, T, C>
 where
     T: fmt::Debug,
     C: cfg::Config,
@@ -834,7 +834,7 @@ where
     }
 }
 
-impl<'a, T, C> PartialEq<T> for Entry<'a, T, C>
+impl<T, C> PartialEq<T> for Entry<'_, T, C>
 where
     T: PartialEq<T>,
     C: cfg::Config,
@@ -853,7 +853,7 @@ where
 
 // === impl VacantEntry ===
 
-impl<'a, T, C: cfg::Config> VacantEntry<'a, T, C> {
+impl<T, C: cfg::Config> VacantEntry<'_, T, C> {
     /// Insert a value in the entry.
     ///
     /// To get the integer index at which this value will be inserted, use

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -870,7 +870,7 @@ where
 
 // === impl Ref ===
 
-impl<'a, T, C> Ref<'a, T, C>
+impl<T, C> Ref<'_, T, C>
 where
     T: Clear + Default,
     C: cfg::Config,
@@ -893,7 +893,7 @@ where
     }
 }
 
-impl<'a, T, C> std::ops::Deref for Ref<'a, T, C>
+impl<T, C> std::ops::Deref for Ref<'_, T, C>
 where
     T: Clear + Default,
     C: cfg::Config,
@@ -905,7 +905,7 @@ where
     }
 }
 
-impl<'a, T, C> Drop for Ref<'a, T, C>
+impl<T, C> Drop for Ref<'_, T, C>
 where
     T: Clear + Default,
     C: cfg::Config,
@@ -927,7 +927,7 @@ where
     }
 }
 
-impl<'a, T, C> fmt::Debug for Ref<'a, T, C>
+impl<T, C> fmt::Debug for Ref<'_, T, C>
 where
     T: fmt::Debug + Clear + Default,
     C: cfg::Config,
@@ -937,7 +937,7 @@ where
     }
 }
 
-impl<'a, T, C> PartialEq<T> for Ref<'a, T, C>
+impl<T, C> PartialEq<T> for Ref<'_, T, C>
 where
     T: PartialEq<T> + Clear + Default,
     C: cfg::Config,
@@ -1014,7 +1014,7 @@ where
     }
 }
 
-impl<'a, T, C: cfg::Config> std::ops::Deref for RefMut<'a, T, C>
+impl<T, C: cfg::Config> std::ops::Deref for RefMut<'_, T, C>
 where
     T: Clear + Default,
     C: cfg::Config,
@@ -1026,7 +1026,7 @@ where
     }
 }
 
-impl<'a, T, C> std::ops::DerefMut for RefMut<'a, T, C>
+impl<T, C> std::ops::DerefMut for RefMut<'_, T, C>
 where
     T: Clear + Default,
     C: cfg::Config,
@@ -1040,7 +1040,7 @@ where
     }
 }
 
-impl<'a, T, C> Drop for RefMut<'a, T, C>
+impl<T, C> Drop for RefMut<'_, T, C>
 where
     T: Clear + Default,
     C: cfg::Config,
@@ -1058,7 +1058,7 @@ where
     }
 }
 
-impl<'a, T, C> fmt::Debug for RefMut<'a, T, C>
+impl<T, C> fmt::Debug for RefMut<'_, T, C>
 where
     T: fmt::Debug + Clear + Default,
     C: cfg::Config,
@@ -1068,7 +1068,7 @@ where
     }
 }
 
-impl<'a, T, C> PartialEq<T> for RefMut<'a, T, C>
+impl<T, C> PartialEq<T> for RefMut<'_, T, C>
 where
     T: PartialEq<T> + Clear + Default,
     C: cfg::Config,


### PR DESCRIPTION
Even with #102 and #103 merged into current main (ee45b4cfa79408fc46893a67f2d3005f79e4e04c), with Rust 1.83 (`rustc 1.83.0 (90b35a623 2024-11-26)`, `cargo 1.83.0 (5ffbef321 2024-10-29)`), running `cargo clippy --all-targets --all-features` gives 16 lifetime-related lint warnings:

<details><summary>Warnings</summary>

```
warning: the following explicit lifetimes could be elided: 'a
   --> src/pool.rs:873:6
    |
873 | impl<'a, T, C> Ref<'a, T, C>
    |      ^^            ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
    = note: `#[warn(clippy::needless_lifetimes)]` on by default
help: elide the lifetimes
    |
873 - impl<'a, T, C> Ref<'a, T, C>
873 + impl<T, C> Ref<'_, T, C>
    |

warning: the following explicit lifetimes could be elided: 'a
   --> src/pool.rs:896:6
    |
896 | impl<'a, T, C> std::ops::Deref for Ref<'a, T, C>
    |      ^^                                ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
896 - impl<'a, T, C> std::ops::Deref for Ref<'a, T, C>
896 + impl<T, C> std::ops::Deref for Ref<'_, T, C>
    |

warning: the following explicit lifetimes could be elided: 'a
   --> src/pool.rs:908:6
    |
908 | impl<'a, T, C> Drop for Ref<'a, T, C>
    |      ^^                     ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
908 - impl<'a, T, C> Drop for Ref<'a, T, C>
908 + impl<T, C> Drop for Ref<'_, T, C>
    |

warning: the following explicit lifetimes could be elided: 'a
   --> src/pool.rs:930:6
    |
930 | impl<'a, T, C> fmt::Debug for Ref<'a, T, C>
    |      ^^                           ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
930 - impl<'a, T, C> fmt::Debug for Ref<'a, T, C>
930 + impl<T, C> fmt::Debug for Ref<'_, T, C>
    |

warning: the following explicit lifetimes could be elided: 'a
   --> src/pool.rs:940:6
    |
940 | impl<'a, T, C> PartialEq<T> for Ref<'a, T, C>
    |      ^^                             ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
940 - impl<'a, T, C> PartialEq<T> for Ref<'a, T, C>
940 + impl<T, C> PartialEq<T> for Ref<'_, T, C>
    |

warning: the following explicit lifetimes could be elided: 'a
    --> src/pool.rs:1017:6
     |
1017 | impl<'a, T, C: cfg::Config> std::ops::Deref for RefMut<'a, T, C>
     |      ^^                                                ^^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
     |
1017 - impl<'a, T, C: cfg::Config> std::ops::Deref for RefMut<'a, T, C>
1017 + impl<T, C: cfg::Config> std::ops::Deref for RefMut<'_, T, C>
     |

warning: the following explicit lifetimes could be elided: 'a
    --> src/pool.rs:1029:6
     |
1029 | impl<'a, T, C> std::ops::DerefMut for RefMut<'a, T, C>
     |      ^^                                      ^^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
     |
1029 - impl<'a, T, C> std::ops::DerefMut for RefMut<'a, T, C>
1029 + impl<T, C> std::ops::DerefMut for RefMut<'_, T, C>
     |

warning: the following explicit lifetimes could be elided: 'a
    --> src/pool.rs:1043:6
     |
1043 | impl<'a, T, C> Drop for RefMut<'a, T, C>
     |      ^^                        ^^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
     |
1043 - impl<'a, T, C> Drop for RefMut<'a, T, C>
1043 + impl<T, C> Drop for RefMut<'_, T, C>
     |

warning: the following explicit lifetimes could be elided: 'a
    --> src/pool.rs:1061:6
     |
1061 | impl<'a, T, C> fmt::Debug for RefMut<'a, T, C>
     |      ^^                              ^^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
     |
1061 - impl<'a, T, C> fmt::Debug for RefMut<'a, T, C>
1061 + impl<T, C> fmt::Debug for RefMut<'_, T, C>
     |

warning: the following explicit lifetimes could be elided: 'a
    --> src/pool.rs:1071:6
     |
1071 | impl<'a, T, C> PartialEq<T> for RefMut<'a, T, C>
     |      ^^                                ^^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
     |
1071 - impl<'a, T, C> PartialEq<T> for RefMut<'a, T, C>
1071 + impl<T, C> PartialEq<T> for RefMut<'_, T, C>
     |

warning: the following explicit lifetimes could be elided: 'a
   --> src/lib.rs:785:6
    |
785 | impl<'a, T, C: cfg::Config> Entry<'a, T, C> {
    |      ^^                           ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
785 - impl<'a, T, C: cfg::Config> Entry<'a, T, C> {
785 + impl<T, C: cfg::Config> Entry<'_, T, C> {
    |

warning: the following explicit lifetimes could be elided: 'a
   --> src/lib.rs:802:6
    |
802 | impl<'a, T, C: cfg::Config> std::ops::Deref for Entry<'a, T, C> {
    |      ^^                                               ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
802 - impl<'a, T, C: cfg::Config> std::ops::Deref for Entry<'a, T, C> {
802 + impl<T, C: cfg::Config> std::ops::Deref for Entry<'_, T, C> {
    |

warning: the following explicit lifetimes could be elided: 'a
   --> src/lib.rs:810:6
    |
810 | impl<'a, T, C: cfg::Config> Drop for Entry<'a, T, C> {
    |      ^^                                    ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
810 - impl<'a, T, C: cfg::Config> Drop for Entry<'a, T, C> {
810 + impl<T, C: cfg::Config> Drop for Entry<'_, T, C> {
    |

warning: the following explicit lifetimes could be elided: 'a
   --> src/lib.rs:827:6
    |
827 | impl<'a, T, C> fmt::Debug for Entry<'a, T, C>
    |      ^^                             ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
827 - impl<'a, T, C> fmt::Debug for Entry<'a, T, C>
827 + impl<T, C> fmt::Debug for Entry<'_, T, C>
    |

warning: the following explicit lifetimes could be elided: 'a
   --> src/lib.rs:837:6
    |
837 | impl<'a, T, C> PartialEq<T> for Entry<'a, T, C>
    |      ^^                               ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
837 - impl<'a, T, C> PartialEq<T> for Entry<'a, T, C>
837 + impl<T, C> PartialEq<T> for Entry<'_, T, C>
    |

warning: the following explicit lifetimes could be elided: 'a
   --> src/lib.rs:856:6
    |
856 | impl<'a, T, C: cfg::Config> VacantEntry<'a, T, C> {
    |      ^^                                 ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
856 - impl<'a, T, C: cfg::Config> VacantEntry<'a, T, C> {
856 + impl<T, C: cfg::Config> VacantEntry<'_, T, C> {
    |

```

</details>

This is particularly problematic because it seems to be causing CI failures in PRs, such as in #102 and #103. This commit uses `cargo clippy --all-targets --all-features --fix` to fix all such warnings.

I confirmed in my [`fix-all-warnings-merged-together`](https://github.com/gretchenfrage/sharded-slab/tree/fix-all-warnings-merged-together) branch that by starting with the current main (ee45b4cfa79408fc46893a67f2d3005f79e4e04c) and merging in #102, #103, and this branch, running `cargo check` and `cargo clippy --all-targets --all-features` complete with no warnings.
