### PR TITLE
chore(docs): Fix docs links

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,8 +111,9 @@
 //!
 //! # Comparison with Similar Crates
 //!
-//! - [`slab`]: Carl Lerche's `slab` crate provides a slab implementation with a
-//!   similar API, implemented by storing all data in a single vector.
+//! - [`slab`][slabcrate]: Carl Lerche's `slab` crate provides a slab implementation
+//!   with a similar API, implemented by storing all data in a single vector.
+//!
 //!
 //!   Unlike `sharded_slab`, inserting and removing elements from the slab
 //!   requires  mutable access. This means that if the slab is accessed
@@ -134,7 +135,7 @@
 //!   concurrent use-cases, while `slab` should be preferred in single-threaded
 //!   use-cases.
 //!
-//! [`slab`]: https://crates.io/crates/loom
+//! [slabcrate]: https://crates.io/crates/slab
 //!
 //! # Safety and Correctness
 //!


### PR DESCRIPTION
Closes #69

As noted in #69, all hyperlinks to `slab` or `Slab` in the lib.rs top-level doc comment link to https://crates.io/crates/loom. This seems to be result of 2 errors dating back to the initial commit, relating to this code:

```rs
//! - [`slab`]: Carl Lerche's `slab` crate provides a slab implementation with a
//!   similar API, implemented by storing all data in a single vector.
...
//! [`slab`]: https://crates.io/crates/loom
```

There seems to be 2 problems with this:

1. The markdown is set up to link `slab` to https://crates.io/crates/loom instead of https://crates.io/crates/slab. There is another part of the doc comment containing `//! [`loom`]: https://crates.io/crates/loom`, so I assume this was a copy-paste error.
2. The markdown is set up to link _all_ occurrences of `slab` to that, and `cargo doc` seems to do this in a case-insensitive way. This means that occurrences of `[`Slab`]` in the comment also get linked to that.

This PR fixes these 2 problems so that `Slab` links in the lib.rs docs link to the `sharded_slab::Slab` item.