### PR TITLE
feat: Add Slab.get_mut

### DIFF
--- a/src/page/mod.rs
+++ b/src/page/mod.rs
@@ -190,6 +190,13 @@ where
         })
     }
 
+    #[inline]
+    #[cfg(not(loom))]
+    pub(crate) fn slot_mut(&mut self, addr: Addr<C>) -> Option<&mut Slot<T, C>> {
+        let poff = addr.offset() - self.prev_sz;
+        self.slab.get_mut().as_mut()?.get_mut(poff)
+    }
+
     #[inline(always)]
     pub(crate) fn free_list(&self) -> &impl FreeList<C> {
         &self.remote

--- a/src/page/slot.rs
+++ b/src/page/slot.rs
@@ -97,6 +97,12 @@ where
     }
 
     #[inline(always)]
+    #[cfg(not(loom))]
+    pub(crate) fn value_mut(&mut self) -> &mut T {
+        self.item.get_mut()
+    }
+
+    #[inline(always)]
     pub(super) fn set_next(&self, next: usize) {
         self.next.with_mut(|n| unsafe {
             (*n) = next;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -102,6 +102,14 @@ mod inner {
         {
             f(self.0.get())
         }
+
+        #[inline(always)]
+        #[cfg(not(loom))]
+        pub fn get_mut(&mut self) -> &mut T {
+            // Safety: same as `std::UnsafeCell::get_mut`
+            // MSRV: `std::UnsafeCell::get_mut` stabilized in 1.50.0
+            unsafe { &mut *self.0.get() }
+        }
     }
 
     pub(crate) mod alloc {


### PR DESCRIPTION
This commit adds a Slab::get_mut method, which takes a `&mut self`, and thus is able to get a mutable reference to an element without actually using any synchronization structures. This is a similar concept to `UnsafeCell::get_mut`, and may be useful for cases such as:

- A sharded `Slab` wrapped in a `RwLock`, such that hot path operations are done through read guards, and rarer and complex operations are done through write guards.
- Any other situation where code has both parallel and serial section, such as in fork-join systems.
- Gradually converting single-threaded systems to parallelizable systems.

The doc comment adds a test that helps ensure basic functionality works.

`test_println!` comments are not added since, as this doesn't actually manipulate any internal structures except the user-provided types, they don't seem that useful in this case.

---

Closes #97