### PR TITLE
feat: Make use of the last bit in Tid

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,7 +226,7 @@ pub use pool::Pool;
 
 pub(crate) use tid::Tid;
 
-use cfg::CfgPrivate;
+use cfg::{CfgPrivate, WIDTH};
 use shard::Shard;
 use std::{fmt, marker::PhantomData, ptr, sync::Arc};
 
@@ -1021,6 +1021,14 @@ where
 {
 }
 
+/// Generate bit mask with `len` 1 bits. (Rust 1.42.0 compatible)
+const fn ones(len: usize) -> usize {
+    let shr = WIDTH - len;
+    let first_shr = shr / 2;
+    // right shift in two passes to avoid overflow
+    0usize.wrapping_sub(1) >> first_shr >> (shr - first_shr)
+}
+
 // === pack ===
 
 pub(crate) trait Pack<C: cfg::Config>: Sized {
@@ -1048,14 +1056,8 @@ pub(crate) trait Pack<C: cfg::Config>: Sized {
     /// left by `Self::SHIFT` bits to calculate this type's `MASK`.
     ///
     /// This is computed automatically based on `Self::LEN`.
-    const BITS: usize = {
-        if Self::LEN == 0 {
-            0
-        } else {
-            let shift = 1 << (Self::LEN - 1);
-            shift | (shift - 1)
-        }
-    };
+    const BITS: usize = ones(Self::LEN);
+
     /// The number of bits to shift a number to pack it into a usize with other
     /// values.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1049,8 +1049,12 @@ pub(crate) trait Pack<C: cfg::Config>: Sized {
     ///
     /// This is computed automatically based on `Self::LEN`.
     const BITS: usize = {
-        let shift = 1 << (Self::LEN - 1);
-        shift | (shift - 1)
+        if Self::LEN == 0 {
+            0
+        } else {
+            let shift = 1 << (Self::LEN - 1);
+            shift | (shift - 1)
+        }
     };
     /// The number of bits to shift a number to pack it into a usize with other
     /// values.

--- a/src/page/slot.rs
+++ b/src/page/slot.rs
@@ -43,7 +43,7 @@ pub(crate) struct Lifecycle<C> {
     state: State,
     _cfg: PhantomData<fn(C)>,
 }
-struct LifecycleGen<C>(Generation<C>);
+pub(crate) struct LifecycleGen<C>(Generation<C>);
 
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 #[repr(usize)]
@@ -702,7 +702,7 @@ impl<C: cfg::Config> Pack<C> for RefCount<C> {
 }
 
 impl<C: cfg::Config> RefCount<C> {
-    pub(crate) const MAX: usize = Self::BITS - 1;
+    pub(crate) const MAX: usize = Self::BITS.saturating_sub(1);
 
     #[inline]
     fn incr(self) -> Option<Self> {

--- a/src/page/slot.rs
+++ b/src/page/slot.rs
@@ -702,7 +702,10 @@ impl<C: cfg::Config> Pack<C> for RefCount<C> {
 }
 
 impl<C: cfg::Config> RefCount<C> {
-    pub(crate) const MAX: usize = Self::BITS.saturating_sub(1);
+    // Basically `Self::BITS.saturaing_sub(1)`, but Rust 1.42.0 compatible.
+    //
+    // Inspired by https://stackoverflow.com/a/53646925/8735881
+    pub(crate) const MAX: usize = [Self::BITS, 1][(Self::BITS < 1) as usize] - 1;
 
     #[inline]
     fn incr(self) -> Option<Self> {

--- a/src/tid.rs
+++ b/src/tid.rs
@@ -43,7 +43,7 @@ thread_local! {
 // === impl Tid ===
 
 impl<C: cfg::Config> Pack<C> for Tid<C> {
-    const LEN: usize = C::MAX_SHARDS.trailing_zeros() as usize + 1;
+    const LEN: usize = C::MAX_SHARDS.trailing_zeros() as usize;
 
     type Prev = page::Addr<C>;
 


### PR DESCRIPTION
Previously `Tid::LEN` was set to `MAX_SHARDS.trailing_zeros() + 1`, and `MAX_SHARDS` was set to `next_pow2(Self::MAX_THREADS - 1)`, which leads to several odd conbinations:

----

```
MAX_THREADS=128
MAX_SHARDS=128
Tid::LEN=8
```

7 bit is enough to encode 128 threads, as the thread id [starts from 0
](https://github.com/hawkw/sharded-slab/blob/e540cdb7daafd6a6e9d17408d3de017029a6637f/src/tid.rs#L161) and [ends with `Tid::BITS`](https://github.com/hawkw/sharded-slab/blob/e540cdb7daafd6a6e9d17408d3de017029a6637f/src/tid.rs#L162), which makes the extra one bit redundant(I can't find the usage of it).

---- 

```
MAX_THREADS=129
MAX_SHARDS=128
Tid::LEN=8
```

As `shards` are [indexed by `Tid`](https://github.com/hawkw/sharded-slab/blob/e540cdb7daafd6a6e9d17408d3de017029a6637f/src/lib.rs#L711), number of shards shouldn't be less than number of threads.

-------

Therefore, I changed the implementation:
- `Tid::LEN` now equals to `MAX_SHARDS.trailing_zeros()`
- `MAX_SHARDS` now equals to `next_pow2(Self::MAX_THREADS)`
- `DefaultConfig::MAX_THREADS` were doubled leveraging the released bit


