### PR TITLE
refactor: replace lazy_static with LazyLock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 env:
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
-  MSRV: 1.42.0
+  MSRV: 1.80.0
 
 jobs:
   build:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,12 +2,12 @@
 name = "sharded-slab"
 version = "0.1.7"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
-edition = "2018"
+edition = "2021"
 documentation = "https://docs.rs/sharded-slab/"
 homepage = "https://github.com/hawkw/sharded-slab"
 repository = "https://github.com/hawkw/sharded-slab"
 readme = "README.md"
-rust-version = "1.42.0"
+rust-version = "1.80.0"
 license = "MIT"
 keywords = ["slab", "allocator", "lock-free", "atomic"]
 categories = ["memory-management", "data-structures", "concurrency"]
@@ -33,7 +33,6 @@ name = "bench"
 harness = false
 
 [dependencies]
-lazy_static = "1"
 
 [dev-dependencies]
 proptest = "1"

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -6,9 +6,7 @@ mod inner {
         pub use loom::sync::atomic::*;
         pub use std::sync::atomic::Ordering;
     }
-    pub(crate) use loom::{
-        cell::UnsafeCell, hint, lazy_static, sync::Mutex, thread::yield_now, thread_local,
-    };
+    pub(crate) use loom::{cell::UnsafeCell, hint, sync::Mutex, thread::yield_now, thread_local};
 
     pub(crate) mod alloc {
         #![allow(dead_code)]
@@ -62,8 +60,6 @@ mod inner {
 
 #[cfg(not(all(loom, any(feature = "loom", test))))]
 mod inner {
-    #![allow(dead_code)]
-    pub(crate) use lazy_static::lazy_static;
     pub(crate) use std::{
         sync::{atomic, Mutex},
         thread::yield_now,
@@ -122,18 +118,6 @@ mod inner {
             #[inline(always)]
             pub fn get_ref(&self) -> &T {
                 &self.value
-            }
-
-            /// Get a mutable reference to the value
-            #[inline(always)]
-            pub fn get_mut(&mut self) -> &mut T {
-                &mut self.value
-            }
-
-            /// Stop tracking the value for leaks
-            #[inline(always)]
-            pub fn into_inner(self) -> T {
-                self.value
             }
         }
     }

--- a/src/tid.rs
+++ b/src/tid.rs
@@ -3,7 +3,7 @@ use crate::{
     page,
     sync::{
         atomic::{AtomicUsize, Ordering},
-        lazy_static, thread_local, Mutex,
+        thread_local, Mutex,
     },
     Pack,
 };
@@ -12,6 +12,7 @@ use std::{
     collections::VecDeque,
     fmt,
     marker::PhantomData,
+    sync::LazyLock,
 };
 
 /// Uniquely identifies a thread.
@@ -29,12 +30,10 @@ struct Registry {
     free: Mutex<VecDeque<usize>>,
 }
 
-lazy_static! {
-    static ref REGISTRY: Registry = Registry {
-        next: AtomicUsize::new(0),
-        free: Mutex::new(VecDeque::new()),
-    };
-}
+static REGISTRY: LazyLock<Registry> = LazyLock::new(|| Registry {
+    next: AtomicUsize::new(0),
+    free: Mutex::new(VecDeque::new()),
+});
 
 thread_local! {
     static REGISTRATION: Registration = Registration::new();


### PR DESCRIPTION
Supercedes #72, closes #71. This commit uses Rust 1.80.0's `LazyLock` to achieve the behavior previously granted by `lazy_static`, which can now be removed.