### PR TITLE
Remove dependency on lazy_static

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,6 @@ maintenance = { status = "experimental" }
 name = "bench"
 harness = false
 
-[dependencies]
-lazy_static = "1"
-
 [dev-dependencies]
 proptest = "1"
 criterion = "0.3"

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -6,9 +6,7 @@ mod inner {
         pub use loom::sync::atomic::*;
         pub use std::sync::atomic::Ordering;
     }
-    pub(crate) use loom::{
-        cell::UnsafeCell, hint, lazy_static, sync::Mutex, thread::yield_now, thread_local,
-    };
+    pub(crate) use loom::{cell::UnsafeCell, hint, sync::Mutex, thread::yield_now, thread_local};
 
     pub(crate) mod alloc {
         #![allow(dead_code)]
@@ -63,7 +61,6 @@ mod inner {
 #[cfg(not(all(loom, any(feature = "loom", test))))]
 mod inner {
     #![allow(dead_code)]
-    pub(crate) use lazy_static::lazy_static;
     pub(crate) use std::{
         sync::{atomic, Mutex},
         thread::yield_now,

--- a/src/tid.rs
+++ b/src/tid.rs
@@ -1,9 +1,11 @@
+use std::sync::LazyLock;
+
 use crate::{
     cfg::{self, CfgPrivate},
     page,
     sync::{
         atomic::{AtomicUsize, Ordering},
-        lazy_static, thread_local, Mutex,
+        thread_local, Mutex,
     },
     Pack,
 };
@@ -29,12 +31,10 @@ struct Registry {
     free: Mutex<VecDeque<usize>>,
 }
 
-lazy_static! {
-    static ref REGISTRY: Registry = Registry {
-        next: AtomicUsize::new(0),
-        free: Mutex::new(VecDeque::new()),
-    };
-}
+static REGISTRY: LazyLock<Registry> = LazyLock::new(|| Registry {
+    next: AtomicUsize::new(0),
+    free: Mutex::new(VecDeque::new()),
+});
 
 thread_local! {
     static REGISTRATION: Registration = Registration::new();


### PR DESCRIPTION
It's in `std::sync` now.

The tests pass, but I'm not sure about the references to loom mocking.

A prereq for this PR is #113 .